### PR TITLE
add ability to set web doc root for web streaming case

### DIFF
--- a/src/ascent/runtimes/ascent_flow_runtime.cpp
+++ b/src/ascent/runtimes/ascent_flow_runtime.cpp
@@ -140,7 +140,12 @@ FlowRuntime::Initialize(const conduit::Node &options)
        options["web/stream"].as_string() == "true" &&
        rank == 0)
     {
-        std::cout << "Enabling Web" << std::endl;
+        
+        if(options.has_path("web/document_root"))
+        {
+            m_web_interface.SetDocumentRoot(options["web/document_root"].as_string());
+        }
+
         m_web_interface.Enable();
     }
 

--- a/src/ascent/runtimes/ascent_main_runtime.cpp
+++ b/src/ascent/runtimes/ascent_main_runtime.cpp
@@ -192,7 +192,12 @@ AscentRuntime::Initialize(const conduit::Node &options)
        options["web/stream"].as_string() == "true" &&
        rank == 0)
     {
-        std::cout << "Enabling Web" << std::endl;
+        
+        if(options.has_path("web/document_root"))
+        {
+            m_web_interface.SetDocumentRoot(options["web/document_root"].as_string());
+        }
+
         m_web_interface.Enable();
     }
 

--- a/src/ascent/utils/ascent_file_system.cpp
+++ b/src/ascent/utils/ascent_file_system.cpp
@@ -57,6 +57,7 @@
 // unix only
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <dirent.h>
 
 //-----------------------------------------------------------------------------
 // -- begin ascent:: --
@@ -79,6 +80,68 @@ create_directory(const std::string &path)
     return  conduit::utils::create_directory(path);
 }
 
+//-----------------------------------------------------------------------------
+bool
+copy_file(const std::string &src_path,
+          const std::string &dest_path)
+{
+    std::ifstream ifile(src_path, std::ios::binary);
+    std::ofstream ofile(dest_path, std::ios::binary);
+
+    ofile << ifile.rdbuf();
+    
+    return true;
+}
+
+
+//-----------------------------------------------------------------------------
+bool
+copy_directory(const std::string &src_path,
+               const std::string &dest_path)
+{
+    bool res = true;
+
+    if(!directory_exists(dest_path))
+    {
+        create_directory(dest_path);
+    }
+
+    DIR *dir;
+    struct dirent *ent;
+    if ((dir = opendir (src_path.c_str())) != NULL)
+    {
+
+        while ( res == true &&  ( (ent = readdir (dir)) != NULL))
+        { 
+            // filter pwd and parent
+            if (ent->d_name != std::string(".") && ent->d_name != std::string("..") )
+            {
+                // check if we have a file or a dir
+                
+                std::string src_child_path = conduit::utils::join_path(src_path,
+                                                                       std::string(ent->d_name));
+                std::string dest_child_path = conduit::utils::join_path(dest_path,
+                                                                        std::string(ent->d_name));
+
+                if(directory_exists(src_child_path))
+                {
+                    res = res && copy_directory(src_child_path, dest_child_path);
+                }
+                else
+                {
+                    res = res && copy_file(src_child_path, dest_child_path);
+                }
+            }
+        }
+        
+        closedir (dir);
+    }
+    else
+    {
+        res = false;
+    }
+    return res;
+}
 
 //-----------------------------------------------------------------------------
 };

--- a/src/ascent/utils/ascent_file_system.hpp
+++ b/src/ascent/utils/ascent_file_system.hpp
@@ -65,6 +65,17 @@ bool directory_exists(const std::string &path);
 // helper to create a directory
 bool create_directory(const std::string &path);
 
+// helper to copy a file to another path
+// always overwrites dest_path
+bool copy_file(const std::string &src_path,
+              const std::string &dest_path);
+
+// helper to copy a directory to another path
+// always overwrites contents of dest_path
+bool copy_directory(const std::string &src_path,
+                    const std::string &dest_path);
+
+
 //-----------------------------------------------------------------------------
 };
 //-----------------------------------------------------------------------------

--- a/src/ascent/utils/ascent_web_interface.cpp
+++ b/src/ascent/utils/ascent_web_interface.cpp
@@ -51,6 +51,7 @@
 #include "ascent_web_interface.hpp"
 
 #include <ascent_config.h>
+#include <ascent_file_system.hpp>
 #include <ascent_logging.hpp>
 
 // thirdparty includes
@@ -72,7 +73,8 @@ namespace ascent
 WebInterface::WebInterface()
 :m_enabled(false),
  m_ms_poll(100),
- m_ms_timeout(100)
+ m_ms_timeout(100),
+ m_doc_root(ASCENT_WEB_CLIENT_ROOT)
 {}
   
 //-----------------------------------------------------------------------------
@@ -81,6 +83,27 @@ WebInterface::~WebInterface()
 }
 
 //-----------------------------------------------------------------------------
+void
+WebInterface::SetDocumentRoot(const std::string &path)
+{
+    m_doc_root = path;
+}
+
+//-----------------------------------------------------------------------------
+void
+WebInterface::SetPoll(int ms_poll)
+{
+    m_ms_poll = ms_poll;
+}
+
+//-----------------------------------------------------------------------------
+void
+WebInterface::SetTimeout(int ms_timeout)
+{
+    m_ms_timeout = ms_timeout;
+}
+
+
 void
 WebInterface::Enable()
 {
@@ -100,7 +123,16 @@ WebInterface::Connection()
     if(!m_server.is_running())
     {
         m_server.set_port(8081);
-        m_server.set_document_root(ASCENT_WEB_CLIENT_ROOT);
+
+        // if we aren't using the standard doc root loc, copy
+        // the necessary web client files to the requested doc root
+        if(m_doc_root != ASCENT_WEB_CLIENT_ROOT)
+        {
+            copy_directory(ASCENT_WEB_CLIENT_ROOT,
+                           m_doc_root);
+        }
+
+        m_server.set_document_root(m_doc_root);
         m_server.serve();
     }
 

--- a/src/tests/ascent/CMakeLists.txt
+++ b/src/tests/ascent/CMakeLists.txt
@@ -51,6 +51,7 @@
 # Core Ascent Unit Tests
 ################################
 set(BASIC_TESTS t_ascent_smoke
+                t_ascent_utils
                 t_ascent_empty_runtime
                 t_ascent_cinema_a
                 t_ascent_render_2d

--- a/src/tests/ascent/t_ascent_utils.cpp
+++ b/src/tests/ascent/t_ascent_utils.cpp
@@ -44,71 +44,46 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: ascent_web_interface.hpp
+/// file: t_ascent_utils.cpp
 ///
 //-----------------------------------------------------------------------------
-#ifndef ASCENT_WEB_INTERFACE_HPP
-#define ASCENT_WEB_INTERFACE_HPP
 
-#include <string>
+#include "gtest/gtest.h"
 
-#include <conduit.hpp>
-#include <conduit_relay.hpp>
+#include <ascent.hpp>
 
-#include <ascent_png_encoder.hpp>
+#include <iostream>
+#include <math.h>
+
+#include "t_config.hpp"
+#include "t_utils.hpp"
+
+
+using namespace std;
+using namespace conduit;
+using namespace ascent;
+
 
 //-----------------------------------------------------------------------------
-// -- begin ascent:: --
-//-----------------------------------------------------------------------------
-namespace ascent
+TEST(ascent_utils, ascent_copy_dir)
 {
-
-class WebInterface
-{
-public:
+    string output_path = conduit::utils::join_path(prepare_output_dir(),"my_folder");
     
-     WebInterface();
-    ~WebInterface();
+    string idx_fpath = conduit::utils::join_path(output_path,"index.html");
 
-    // Note: Set methods must be called before first call 
-    // to Push methods.
-
-    // if set, Ascent's web resources (html, js files, etc) are
-    // are copied to and server at the given path
-    // if not set, they are served out of ASCENT_WEB_CLIENT_ROOT
+    // for multiple runs of this test:
+    //  we don't have a util to kill the entire dir, so 
+    //  we simply remove a known file, and check that the copy restores it
     
-    void                            SetDocumentRoot(const std::string &path);
-    void                            SetPoll(int ms_poll);
-    void                            SetTimeout(int ms_timeout);
+    if(conduit::utils::is_file(idx_fpath))
+    {
+        conduit::utils::remove_file(idx_fpath);
+    }
 
-    void                            Enable();
-        
-    void                            PushMessage(const conduit::Node &msg);
-    void                            PushRenders(const conduit::Node &renders);
-        
-private:
-
-    conduit::relay::web::WebSocket *Connection();
-
-    void                            EncodeImage(const std::string &png_file_path,
-                                                conduit::Node &out);
-    bool                            m_enabled;
-    conduit::relay::web::WebServer  m_server;
-    int                             m_ms_poll;
-    int                             m_ms_timeout;
-    std::string                     m_doc_root;
-
-};
-
-//-----------------------------------------------------------------------------
-};
-//-----------------------------------------------------------------------------
-// -- end ascent:: --
-//-----------------------------------------------------------------------------
-
-#endif
-//-----------------------------------------------------------------------------
-// -- end header ifdef guard
-//-----------------------------------------------------------------------------
-
+    
+    ascent::copy_directory(ASCENT_WEB_CLIENT_ROOT, output_path);
+    
+    EXPECT_TRUE(directory_exists(conduit::utils::join_path(output_path,"resources")));
+    EXPECT_TRUE(conduit::utils::is_file(idx_fpath));
+}
 

--- a/src/tests/ascent/t_ascent_web_flow.cpp
+++ b/src/tests/ascent/t_ascent_web_flow.cpp
@@ -69,6 +69,8 @@ using namespace ascent;
 const float64 PI_VALUE = 3.14159265359;
 
 bool launch_server = false;
+bool use_doc_root  = false;
+std::string doc_root = "";
 
 #include <flow.hpp>
 
@@ -107,53 +109,6 @@ public:
 
 };
 
-// //-----------------------------------------------------------------------------
-// TEST(ascent_web, test_ascent_web_launch)
-// {
-//     flow::Workspace::register_filter_type<InspectFilter>();
-//
-//
-//     //
-//     // Create example mesh.
-//     //
-//     Node data, verify_info;
-//     conduit::blueprint::mesh::examples::braid("quads",100,100,0,data);
-//
-//     EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
-//     verify_info.print();
-//
-//     Node actions;
-//     actions.append();
-//     actions[0]["action"] = "add_filter";
-//     actions[0]["type_name"]  = "inspect";
-//     actions[0]["name"] = "fi";
-//
-//     actions.append();
-//     actions[1]["action"] = "connect";
-//     actions[1]["src"]  = "source";
-//     actions[1]["dest"] = "fi";
-//     actions[1]["port"] = "in";
-//
-//     actions.append()["action"] = "execute";
-//     actions.print();
-//
-//     // we want the "flow" runtime
-//     Node open_opts;
-//     open_opts["runtime/type"] = "flow";
-//
-//     Node ascent_info;
-//     //
-//     // Run Ascent
-//     //
-//     Ascent ascent;
-//     ascent.open(open_opts);
-//     ascent.publish(data);
-//     ascent.execute(actions);
-//     ascent.info(ascent_info);
-//     EXPECT_EQ(ascent_info["runtime/type"].as_string(),"flow");
-//     ascent_info.print();
-//     ascent.close();
-// }
 
 //-----------------------------------------------------------------------------
 TEST(ascent_web, test_ascent_web_launch)
@@ -196,6 +151,10 @@ TEST(ascent_web, test_ascent_web_launch)
     Node open_opts;
     open_opts["runtime/type"] = "flow";
     open_opts["web/stream"] = "true";
+    if(use_doc_root)
+    {
+        open_opts["web/document_root"] = doc_root;
+    }
     open_opts["ascent_info"] = "verbose";
     
     Ascent ascent;
@@ -238,6 +197,12 @@ int main(int argc, char* argv[])
         if(arg_str == "launch")
         {
             launch_server = true;;
+        }
+        else if(arg_str == "doc_root" && (i+1 < argc) )
+        {
+            use_doc_root = true;
+            doc_root = std::string(argv[i+1]);
+            i++;
         }
     }
 

--- a/src/tests/ascent/t_ascent_web_main.cpp
+++ b/src/tests/ascent/t_ascent_web_main.cpp
@@ -69,6 +69,8 @@ using namespace ascent;
 const float64 PI_VALUE = 3.14159265359;
 
 bool launch_server = false;
+bool use_doc_root  = false;
+std::string doc_root = "";
 
 #include <flow.hpp>
 
@@ -121,6 +123,10 @@ TEST(ascent_web, test_ascent_main_web_launch)
     Node open_opts;
     open_opts["runtime/type"] = "ascent";
     open_opts["web/stream"] = "true";
+    if(use_doc_root)
+    {
+        open_opts["web/document_root"] = doc_root;
+    }
     open_opts["ascent_info"] = "verbose";
     
     Ascent ascent;
@@ -162,6 +168,12 @@ int main(int argc, char* argv[])
         if(arg_str == "launch")
         {
             launch_server = true;;
+        }
+        else if(arg_str == "doc_root" && (i+1 < argc) )
+        {
+            use_doc_root = true;
+            doc_root = std::string(argv[i+1]);
+            i++;
         }
     }
 


### PR DESCRIPTION
adds utils for copying files and directories 
adds test for copying directories
adds Ascent option (web/document_root) that allows user to select where the web server doc root is, the Ascent web client resources (html files, js files, etc) are copied to this directory
