### PR TITLE
refactor source filter logic for ascent and flow runtimes

### DIFF
--- a/src/ascent/runtimes/ascent_flow_runtime.cpp
+++ b/src/ascent/runtimes/ascent_flow_runtime.cpp
@@ -169,7 +169,21 @@ FlowRuntime::Publish(const conduit::Node &data)
 {
     // create our own tree, with all data zero copied.
     m_data.set_external(data);
-    
+}
+
+//-----------------------------------------------------------------------------
+void
+FlowRuntime::ResetInfo()
+{
+    m_info.reset();
+    m_info["runtime/type"] = "flow";
+    m_info["runtime/options"] = m_runtime_options;
+}
+
+//-----------------------------------------------------------------------------
+void 
+FlowRuntime::ConnectSource()
+{
     // note: if the reg entry for data was already added
     // the set_external updates everything,
     // we don't need to remove and re-add.
@@ -189,20 +203,11 @@ FlowRuntime::Publish(const conduit::Node &data)
 
 //-----------------------------------------------------------------------------
 void
-FlowRuntime::ResetInfo()
-{
-    m_info.reset();
-    m_info["runtime/type"] = "flow";
-    m_info["runtime/options"] = m_runtime_options;
-}
-
-
-//-----------------------------------------------------------------------------
-void
 FlowRuntime::Execute(const conduit::Node &actions)
 {
     ResetInfo();
-    
+    // make sure we always have our source data
+    ConnectSource();
     // Loop over the actions
     for (int i = 0; i < actions.number_of_children(); ++i)
     {

--- a/src/ascent/runtimes/ascent_flow_runtime.hpp
+++ b/src/ascent/runtimes/ascent_flow_runtime.hpp
@@ -97,6 +97,7 @@ private:
     flow::Workspace w;
     
     void              ResetInfo();
+    void              ConnectSource();
     
     WebInterface      m_web_interface;
     

--- a/src/ascent/runtimes/ascent_main_runtime.cpp
+++ b/src/ascent/runtimes/ascent_main_runtime.cpp
@@ -233,22 +233,6 @@ AscentRuntime::Publish(const conduit::Node &data)
 {
     // create our own tree, with all data zero copied.
     m_data.set_external(data);
-    
-    // note: if the reg entry for data was already added
-    // the set_external updates everything,
-    // we don't need to remove and re-add.
-    if(!w.registry().has_entry("_ascent_input_data"))
-    {
-        w.registry().add<Node>("_ascent_input_data",
-                               &m_data);
-    }
-
-    if(!w.graph().has_filter("source"))
-    {
-       Node p;
-       p["entry"] = "_ascent_input_data";
-       w.graph().add_filter("registry_source","source",p);
-    }
 }
 
 //-----------------------------------------------------------------------------
@@ -553,6 +537,28 @@ AscentRuntime::CreateExtracts(const conduit::Node &extracts)
     ConvertExtractToFlow(extract, names[i]);
   }
 }
+
+//-----------------------------------------------------------------------------
+void 
+AscentRuntime::ConnectSource()
+{
+    // note: if the reg entry for data was already added
+    // the set_external updates everything,
+    // we don't need to remove and re-add.
+    if(!w.registry().has_entry("_ascent_input_data"))
+    {
+        w.registry().add<Node>("_ascent_input_data",
+                               &m_data);
+    }
+
+    if(!w.graph().has_filter("source"))
+    {
+       Node p;
+       p["entry"] = "_ascent_input_data";
+       w.graph().add_filter("registry_source","source",p);
+    }
+}
+
 //-----------------------------------------------------------------------------
 void 
 AscentRuntime::ConnectGraphs()
@@ -875,6 +881,8 @@ void
 AscentRuntime::Execute(const conduit::Node &actions)
 {
     ResetInfo();
+    // make sure we always have our source data
+    ConnectSource();
     // Loop over the actions
     for (int i = 0; i < actions.number_of_children(); ++i)
     {

--- a/src/ascent/runtimes/ascent_main_runtime.hpp
+++ b/src/ascent/runtimes/ascent_main_runtime.hpp
@@ -111,6 +111,7 @@ private:
     std::vector<std::string> GetPipelines(const conduit::Node &plots);
     void CreateScenes(const conduit::Node &scenes);
     void ConvertSceneToFlow(const conduit::Node &scenes);
+    void ConnectSource();
     void ConnectGraphs();
     void ExecuteGraphs();
     std::string GetDefaultImagePrefix(const std::string scene);


### PR DESCRIPTION
check for and create flow filter and registry entry for source data at execute, instead of at publish

Allows us to better support cases where publish is called once (data values are described in a way that everything is zero-copied -- lulesh serves as an example for this case)
