### PR TITLE
refactor verbosity setting, provide option to catch exceptions

### DIFF
--- a/src/ascent/ascent.cpp
+++ b/src/ascent/ascent.cpp
@@ -77,7 +77,9 @@ quiet_handler(const std::string &,
 
 //-----------------------------------------------------------------------------
 Ascent::Ascent()
-: m_runtime(NULL)
+: m_runtime(NULL),
+  m_verbose_msgs(false),
+  m_forward_exceptions(true)
 {
 }
 
@@ -113,103 +115,172 @@ CheckForJSONFile(std::string file_name, conduit::Node &node)
 void
 Ascent::open(const conduit::Node &options)
 {
-    Node processed_opts(options);
-    CheckForJSONFile("ascent_options.json", processed_opts); 
-    if(m_runtime != NULL)
+    try
     {
-        ASCENT_ERROR("Ascent Runtime already exists.!");
-    }
-
-    bool quiet_output = true; 
-    if(options.has_path("ascent_info"))
-    {
-        if(options["ascent_info"].as_string() == "verbose")
+        if(m_runtime != NULL)
         {
-            quiet_output = false;
+            ASCENT_ERROR("Ascent Runtime already exists!");
         }
-    }
 
-    if(quiet_output)
-    {
-        conduit::utils::set_info_handler(quiet_handler);
-    }
+        Node processed_opts(options);
+        CheckForJSONFile("ascent_options.json", processed_opts); 
 
-    Node cfg;
-    ascent::about(cfg);
+        if(options.has_path("messages") && 
+           options["messages"].dtype().is_string() )
+        {
+            std::string msgs_opt = options["messages"].as_string();
+            if( msgs_opt == "verbose")
+            {
+                m_verbose_msgs = true;
+            }
+            else if(msgs_opt == "quite")
+            {
+                m_verbose_msgs = false;
+            }
+        }
+
+        if(options.has_path("exceptions") && 
+           options["exceptions"].dtype().is_string() )
+        {
+            std::string excp_opt = options["exceptions"].as_string();
+            if( excp_opt == "catch")
+            {
+                m_forward_exceptions = false;
+            }
+            else if(excp_opt == "throw")
+            {
+                m_forward_exceptions = true;
+            }
+        }
+        
+        // don't print info messages unless we are using verbose
+        if(!m_verbose_msgs)
+        {
+            conduit::utils::set_info_handler(quiet_handler);
+        }
+
+        Node cfg;
+        ascent::about(cfg);
     
-    std::string runtime_type = cfg["default_runtime"].as_string();
+        std::string runtime_type = cfg["default_runtime"].as_string();
     
-    if(processed_opts.has_path("runtime"))
-    {
-        if(processed_opts.has_path("runtime/type"))
+        if(processed_opts.has_path("runtime"))
         {
-            runtime_type = processed_opts["runtime/type"].as_string();
+            if(processed_opts.has_path("runtime/type"))
+            {
+                runtime_type = processed_opts["runtime/type"].as_string();
+            }
         }
-    }
 
-    ASCENT_INFO("Runtime Type = " << runtime_type);
+        ASCENT_INFO("Runtime Type = " << runtime_type);
 
-    if(runtime_type == "empty")
-    {
-        m_runtime = new EmptyRuntime();
-    }
-    else if(runtime_type == "ascent")
-    {
-#if defined(ASCENT_VTKH_ENABLED)
-        m_runtime = new AscentRuntime();
-        if(processed_opts.has_path("runtime/backend"))
+        if(runtime_type == "empty")
         {
-          std::string backend = processed_opts["runtime/backend"].as_string();
-          if(backend == "serial")
-          {
-            vtkh::ForceSerial();
-          }
-          else if(backend == "tbb")
-          {
-            vtkh::ForceTBB();
-          }
-          else if(backend == "cuda")
-          {
-            vtkh::ForceCUDA();
-          }
-          else
-          {
-            ASCENT_ERROR("Ascent unrecognized backend "<<backend);
-          }
+            m_runtime = new EmptyRuntime();
         }
-#else
-        ASCENT_ERROR("Ascent runtime is disabled. "
-                     "Ascent was not built with vtk-h support");
-#endif
-    }
-    else if(runtime_type == "flow")
-    {
-        m_runtime = new FlowRuntime();
-    }
-    else
-    {
-        ASCENT_ERROR("Unsupported Runtime type " 
-                       << "\"" << m_runtime << "\""
-                       << " passed via 'runtime' open option.");
-    }
+        else if(runtime_type == "ascent")
+        {
+    #if defined(ASCENT_VTKH_ENABLED)
+            m_runtime = new AscentRuntime();
+            if(processed_opts.has_path("runtime/backend"))
+            {
+              std::string backend = processed_opts["runtime/backend"].as_string();
+              if(backend == "serial")
+              {
+                vtkh::ForceSerial();
+              }
+              else if(backend == "tbb")
+              {
+                vtkh::ForceTBB();
+              }
+              else if(backend == "cuda")
+              {
+                vtkh::ForceCUDA();
+              }
+              else
+              {
+                ASCENT_ERROR("Ascent unrecognized backend "<<backend);
+              }
+            }
+    #else
+            ASCENT_ERROR("Ascent runtime is disabled. "
+                         "Ascent was not built with vtk-h support");
+    #endif
+        }
+        else if(runtime_type == "flow")
+        {
+            m_runtime = new FlowRuntime();
+        }
+        else
+        {
+            ASCENT_ERROR("Unsupported Runtime type " 
+                           << "\"" << runtime_type << "\""
+                           << " passed via 'runtime' open option.");
+        }
      
-    m_runtime->Initialize(processed_opts);
+        m_runtime->Initialize(processed_opts);
+    }
+    catch(conduit::Error &e)
+    {
+        if(m_forward_exceptions)
+        {
+            throw;
+        }
+        else
+        {
+            // NOTE: CONDUIT_INFO could be muted, so we use std::cout
+            std::cout << "[Error] Ascent::open " 
+                      << e.message() << std::endl;
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
 void
 Ascent::publish(const conduit::Node &data)
 {
-    m_runtime->Publish(data);
+    try
+    {
+        m_runtime->Publish(data);
+    }
+    catch(conduit::Error &e)
+    {
+        if(m_forward_exceptions)
+        {
+            throw;
+        }
+        else
+        {
+            // NOTE: CONDUIT_INFO could be muted, so we use std::cout
+            std::cout << "[Error] Ascent::publish " 
+                      << e.message() << std::endl;
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
 void
 Ascent::execute(const conduit::Node &actions)
 {
-    Node processed_actions(actions);
-    CheckForJSONFile("ascent_actions.json", processed_actions);
-    m_runtime->Execute(processed_actions);
+    try
+    {
+        Node processed_actions(actions);
+        CheckForJSONFile("ascent_actions.json", processed_actions);
+        m_runtime->Execute(processed_actions);
+    }
+    catch(conduit::Error &e)
+    {
+        if(m_forward_exceptions)
+        {
+            throw;
+        }
+        else
+        {
+            // NOTE: CONDUIT_INFO could be muted, so we use std::cout
+            std::cout << "[Error] Ascent::execute " 
+                      << e.message() << std::endl;
+        }
+    }
 }
 
 
@@ -217,9 +288,25 @@ Ascent::execute(const conduit::Node &actions)
 void
 Ascent::info(conduit::Node &info_out)
 {
-    if(m_runtime != NULL)
+    try
     {
-        m_runtime->Info(info_out);
+        if(m_runtime != NULL)
+        {
+            m_runtime->Info(info_out);
+        }
+    }
+    catch(conduit::Error &e)
+    {
+        if(m_forward_exceptions)
+        {
+            throw;
+        }
+        else
+        {
+            // NOTE: CONDUIT_INFO could be muted, so we use std::cout
+            std::cout << "[Error] Ascent::info " 
+                      << e.message() << std::endl;
+        }
     }
 }
 
@@ -227,11 +314,27 @@ Ascent::info(conduit::Node &info_out)
 void
 Ascent::close()
 {
-    if(m_runtime != NULL)
+    try
     {
-        m_runtime->Cleanup();
-        delete m_runtime;
-        m_runtime = NULL;
+        if(m_runtime != NULL)
+        {
+            m_runtime->Cleanup();
+            delete m_runtime;
+            m_runtime = NULL;
+        }
+    }
+    catch(conduit::Error &e)
+    {
+        if(m_forward_exceptions)
+        {
+            throw;
+        }
+        else
+        {
+            // NOTE: CONDUIT_INFO could be muted, so we use std::cout
+            std::cout << "[Error] Ascent::close " 
+                      << e.message() << std::endl;
+        }
     }
 }
 
@@ -288,7 +391,7 @@ void
 about(conduit::Node &n)
 {
     n.reset();
-    n["version"] = "0.1.0";
+    n["version"] = "0.2.1.pre";
 
 #if defined(ASCENT_MPI_ENABLED)
     n["mpi"] = "enabled";

--- a/src/ascent/ascent.cpp
+++ b/src/ascent/ascent.cpp
@@ -133,7 +133,7 @@ Ascent::open(const conduit::Node &options)
             {
                 m_verbose_msgs = true;
             }
-            else if(msgs_opt == "quite")
+            else if(msgs_opt == "quiet")
             {
                 m_verbose_msgs = false;
             }

--- a/src/docs/sphinx/AscentAPI.rst
+++ b/src/docs/sphinx/AscentAPI.rst
@@ -51,10 +51,12 @@ The top level API for ascent consists of four calls:
   - Execute(conduit::Node)
   - Close()
 
+.. _ascent_api_open:
+
 Open
 ----
 Open provides the initial setup of Ascent from a Conduit Node. 
-Options include runtime type (e.g., main, flow, or empty) and associated backend if available.
+Options include runtime type (e.g., ascent, flow, or empty) and associated backend if available.
 If running in parallel (i.e., MPI), then a MPI comm handle must be supplied.
 Ascent will always check the file system for a file called ``ascent_options.json`` that will override compiled in options, and for obvious reasons, a MPI communicator cannot be specified in the file.
 Here is a file that would set the runtime to the main ascent runtime using a TBB backend (inside VTK-m):
@@ -84,11 +86,37 @@ A typical integration will include the following code:
 
 Valid runtimes include:
 
-  - ascent
+  - ``ascent``
     
-  - flow
+  - ``flow``
 
-  - empty
+  - ``empty``
+
+
+There are a few other options that control behaviors common to all runtimes:
+
+ * ``messages``
+
+   Controls if logged info messages are printed or muted.
+  
+   Supported values:
+   
+    - ``quiet`` (default if omitted) Logged info messages are muted 
+
+    - ``verbose``  Logged info messages are printed
+
+
+ * ``exceptions``
+ 
+   Controls if Ascent traps or forwards C++ exceptions that are thrown.
+   
+   Supported values:
+    
+    - ``forward`` (default if omitted) Exceptions thrown will propagate to the calling code 
+
+    -  ``catch`` Catches conduit::Error exceptions at the Ascent interface and prints info about the error to standard out. 
+       This case this provides an easy way to prevent host program crashes when something goes wrong in Ascent.
+  
   
 Publish
 -------
@@ -188,6 +216,7 @@ Error Handling
   Ascent uses Conduit's error handling machinery. By default when errors occur 
   C++ exceptions are thrown, but you can rewire Conduit's handlers with your own callbacks. For more info
   see the `Conduit Error Handling Tutorial <http://software.llnl.gov/conduit/tutorial_errors.html>`_.
+  You can also stop exceptions at the Ascent interface using the ``exceptions`` option for :ref:`Ascent::open<ascent_api_open>` .
 
 
 

--- a/src/tests/ascent/CMakeLists.txt
+++ b/src/tests/ascent/CMakeLists.txt
@@ -51,6 +51,7 @@
 # Core Ascent Unit Tests
 ################################
 set(BASIC_TESTS t_ascent_smoke
+                t_ascent_runtime_options
                 t_ascent_empty_runtime
                 t_ascent_cinema_a
                 t_ascent_render_2d

--- a/src/tests/ascent/t_ascent_runtime_options.cpp
+++ b/src/tests/ascent/t_ascent_runtime_options.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2015-2017, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
 // 
 // Produced at the Lawrence Livermore National Laboratory
 // 
@@ -44,7 +44,7 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: t_ascent_empty_runtime.cpp
+/// file: t_ascent_runtime_options.cpp
 ///
 //-----------------------------------------------------------------------------
 

--- a/src/tests/ascent/t_ascent_runtime_options.cpp
+++ b/src/tests/ascent/t_ascent_runtime_options.cpp
@@ -99,7 +99,7 @@ TEST(ascent_runtime_options, verbose_msgs)
 }
 
 //-----------------------------------------------------------------------------
-TEST(ascent_runtime_options, quite_msgs)
+TEST(ascent_runtime_options, quiet_msgs)
 {
     //
     // Create example mesh.
@@ -118,7 +118,7 @@ TEST(ascent_runtime_options, quite_msgs)
     // we want the "empty" example pipeline
     Node open_opts;
     open_opts["runtime/type"] = "empty";
-    open_opts["messages"] = "quite";
+    open_opts["messages"] = "quiet";
     
     //
     // Run Ascent


### PR DESCRIPTION
changes to Ascent::open() options

* Instead of accepting `ascent_info`, accept `messages`, valid entries are `quiet` or `verbose`

Controls if ASCENT_INFO messages are printed or muted.

`quiet` is the default case, ASCENT_INFO messages are muted

`verbose` enables printing of ASCENT_INFO messages 


* Add `exceptions` option, valid entries are `forward` or `catch`

`forward` is the default, and preserves the old behavior, where if an exception is thrown the calling app will need to handle it

`catch` catches conduit::Error exceptions at the interface. It's an important option b/c it provides an easy way to prevent program crashes when something goes wrong in ascent. 

