### PR TITLE
use obj lib to avoid fortran module gen collision

### DIFF
--- a/src/ascent/CMakeLists.txt
+++ b/src/ascent/CMakeLists.txt
@@ -136,7 +136,8 @@ endif()
 #############################
 
 if(FORTRAN_FOUND)
-    list(APPEND ascent_sources fortran/ascent_fortran.f90)
+    add_library(ascent_fortran OBJECT fortran/ascent_fortran.f90)
+    list(APPEND ascent_sources $<TARGET_OBJECTS:ascent_fortran>)
 endif()
 
 ################################


### PR DESCRIPTION
fixes long standing #33  issue with fortran

We were including the ascent_fortran.f90 source in two targets. In parallel those two targets would both generate the module and step on each other. Switched to use an object library to resolve.
