### PR TITLE
Correct type of cached CMake variables

### DIFF
--- a/host-configs/Darwin.cmake
+++ b/host-configs/Darwin.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ###############################################################################

--- a/host-configs/boilerplate.cmake
+++ b/host-configs/boilerplate.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ##################################
@@ -62,10 +62,10 @@ set(CMAKE_CXX_COMPILER "/path/to/cxx_compiler" CACHE PATH "")
 set(CMAKE_Fortran_COMPILER  "/path/to/fortran_compiler" CACHE PATH "")
 
 # OPENMP (optional: for proxy apps)
-set(ENABLE_OPENMP ON CACHE PATH "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 # MPI Support
-set(ENABLE_MPI  ON CACHE PATH "")
+set(ENABLE_MPI  ON CACHE BOOL "")
 
 set(MPI_C_COMPILER  "/path/to/mpi_c_compiler" CACHE PATH "")
 
@@ -80,15 +80,15 @@ set(MPIEXEC_NUMPROC_FLAG -n CACHE PATH "")
 
 
 # CUDA support
-#set(ENABLE_CUDA ON CACHE PATH "")
+#set(ENABLE_CUDA ON CACHE BOOL "")
 
 # NO CUDA Support
-set(ENABLE_CUDA OFF CACHE PATH "")
+set(ENABLE_CUDA OFF CACHE BOOL "")
 
-# conduit 
+# conduit
 set(CONDUIT_DIR "/path/to/conduit_install/" CACHE PATH "")
 
-# icet 
+# icet
 set(ICET_DIR "/path/to/icet_install/" CACHE PATH "")
 
 #

--- a/host-configs/surface10-chaos_5_x86_64_ib-gcc@4.9.3.cmake
+++ b/host-configs/surface10-chaos_5_x86_64_ib-gcc@4.9.3.cmake
@@ -18,12 +18,12 @@ set("CMAKE_C_COMPILER" "/usr/apps/gnu/4.9.3/bin/gcc" CACHE PATH "")
 set("CMAKE_CXX_COMPILER" "/usr/apps/gnu/4.9.3/bin/g++" CACHE PATH "")
 
 # fortran compiler used by spack
-set("ENABLE_FORTRAN" "ON" CACHE PATH "")
+set("ENABLE_FORTRAN" "ON" CACHE BOOL "")
 
 set("CMAKE_Fortran_COMPILER" "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")
 
 # Enable python module builds
-set("ENABLE_PYTHON" "ON" CACHE PATH "")
+set("ENABLE_PYTHON" "ON" CACHE BOOL "")
 
 # python from uberenv
 set("PYTHON_EXECUTABLE" "/usr/workspace/wsa/visit/alpine/uberenv_libs/spack/opt/spack/chaos_5_x86_64_ib/gcc-4.9.3/python-2.7.11-eujx7frnxd5vpwolmye2fzq4tcylnbnv/bin/python" CACHE PATH "")
@@ -32,10 +32,10 @@ set("PYTHON_EXECUTABLE" "/usr/workspace/wsa/visit/alpine/uberenv_libs/spack/opt/
 set("SPHINX_EXECUTABLE" "/usr/workspace/wsa/visit/alpine/uberenv_libs/spack/opt/spack/chaos_5_x86_64_ib/gcc-4.9.3/python-2.7.11-eujx7frnxd5vpwolmye2fzq4tcylnbnv/bin/sphinx-build" CACHE PATH "")
 
 # OPENMP Support
-set("ENABLE_OPENMP" "OFF" CACHE PATH "")
+set("ENABLE_OPENMP" "OFF" CACHE BOOL "")
 
 # MPI Support
-set("ENABLE_MPI" "ON" CACHE PATH "")
+set("ENABLE_MPI" "ON" CACHE BOOL "")
 
 set("MPI_C_COMPILER" "/usr/local/tools/mvapich2-gnu-2.0/bin/mpicc" CACHE PATH "")
 
@@ -44,7 +44,7 @@ set("MPI_CXX_COMPILER" "/usr/local/tools/mvapich2-gnu-2.0/bin/mpicc" CACHE PATH 
 set("MPI_Fortran_COMPILER" "/usr/local/tools/mvapich2-gnu-2.0/bin/mpif90" CACHE PATH "")
 
 # CUDA support
-set("ENABLE_CUDA" "ON" CACHE PATH "")
+set("ENABLE_CUDA" "ON" CACHE BOOL "")
 
 set("CUDA_BIN_DIR" "/opt/cudatoolkit-8.0/bin" CACHE PATH "")
 

--- a/host-configs/surface86-chaos_5_x86_64_ib-intel@14.0.3.cmake
+++ b/host-configs/surface86-chaos_5_x86_64_ib-intel@14.0.3.cmake
@@ -65,10 +65,10 @@ set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc" CACHE PATH "")
 set(CMAKE_Fortran_COMPILER  "/usr/local/bin/ifort" CACHE PATH "")
 
 # OPENMP Support
-set(ENABLE_OPENMP ON CACHE PATH "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 # MPI Support
-set(ENABLE_MPI  ON CACHE PATH "")
+set(ENABLE_MPI  ON CACHE BOOL "")
 
 set(MPI_C_COMPILER  "/usr/local/tools/mvapich2-intel-2.0/bin/mpicc" CACHE PATH "")
 
@@ -83,8 +83,8 @@ set(MPIEXEC_NUMPROC_FLAG -n CACHE PATH "")
 
 
 # CUDA support
-set(ENABLE_CUDA ON CACHE PATH "")
-#set(ENABLE_CUDA OFF CACHE PATH "")
+set(ENABLE_CUDA ON CACHE BOOL "")
+#set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(CUDA_BIN_DIR /opt/cudatoolkit-7.0/bin CACHE PATH "")
 

--- a/host-configs/whoopingcough.cmake
+++ b/host-configs/whoopingcough.cmake
@@ -64,10 +64,10 @@ set(CXX_COMPILE_FLAGS "-fPIC" CACHE PATH "")
 set(CMAKE_Fortran_COMPILER  "/usr/bin/f95" CACHE PATH "")
 
 # OPENMP (optional: for proxy apps)
-set(ENABLE_OPENMP OFF CACHE PATH "")
+set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 # MPI Support
-set(ENABLE_MPI  ON CACHE PATH "")
+set(ENABLE_MPI  ON CACHE BOOL "")
 
 set(MPI_C_COMPILER  "/usr/bin/mpicc" CACHE PATH "")
 set(MPI_C_COMPILE_FLAGS "-fPIC" CACHE PATH "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ option(ENABLE_EXAMPLES    "Build Examples"            ON)
 ################################
 # Populate the cmake gui
 ################################
-set(CONDUIT_DIR "" CACHE FILEPATH "path to conduit installation")
+set(CONDUIT_DIR "" CACHE PATH "path to conduit installation")
 
 ################################
 # Invoke CMake Fortran setup

--- a/src/cmake/CMakeBasics.cmake
+++ b/src/cmake/CMakeBasics.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 
@@ -131,7 +131,7 @@ endif()
 # git HEAD changes or when a branch is checked out, unless a change causes
 # cmake to reconfigure.
 #
-# However, this limited approach will still be useful in many cases, 
+# However, this limited approach will still be useful in many cases,
 # including building and for installing ascent as a tpl
 #
 ##############################################################################

--- a/src/cmake/Setup3rdParty.cmake
+++ b/src/cmake/Setup3rdParty.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ################################
@@ -107,7 +107,7 @@ endif()
 
 ################################
 # Setup MFEM
-################################  
+################################
 if (MFEM_DIR)
   include(cmake/thirdparty/SetupMFEM.cmake)
 endif()
@@ -115,7 +115,7 @@ endif()
 
 ################################
 # Setup ADIOS
-################################  
+################################
 if (ADIOS_DIR)
   include(cmake/thirdparty/SetupADIOS.cmake)
 endif()

--- a/src/cmake/SetupFortran.cmake
+++ b/src/cmake/SetupFortran.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ################################

--- a/src/cmake/SetupIncludes.cmake
+++ b/src/cmake/SetupIncludes.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 

--- a/src/cmake/SetupTests.cmake
+++ b/src/cmake/SetupTests.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ##------------------------------------------------------------------------------
@@ -55,8 +55,8 @@ function(add_cpp_test)
 
     # parse our arguments
     cmake_parse_arguments(arg
-                         "${options}" 
-                         "${singleValueArgs}" 
+                         "${options}"
+                         "${singleValueArgs}"
                          "${multiValueArgs}" ${ARGN} )
 
     message(STATUS " [*] Adding Unit Test: ${arg_TEST}")
@@ -86,8 +86,8 @@ function(add_cuda_test)
 
     # parse our arguments
     cmake_parse_arguments(arg
-                         "${options}" 
-                         "${singleValueArgs}" 
+                         "${options}"
+                         "${singleValueArgs}"
                          "${multiValueArgs}" ${ARGN} )
 
     message(STATUS " [*] Adding CUDA Unit Test: ${arg_TEST}")
@@ -117,22 +117,22 @@ function(add_cpp_mpi_test)
 
     # parse our arguments
     cmake_parse_arguments(arg
-                         "${options}" 
-                         "${singleValueArgs}" 
+                         "${options}"
+                         "${singleValueArgs}"
                          "${multiValueArgs}" ${ARGN} )
 
     message(STATUS " [*] Adding Unit Test: ${arg_TEST}")
-    
-    
+
+
     blt_add_executable( NAME ${arg_TEST}
                         SOURCES ${arg_TEST}.cpp ${fortran_driver_source}
                         OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}
                         DEPENDS_ON "${arg_DEPENDS_ON}" gtest mpi)
-                        
+
     blt_add_test( NAME ${arg_TEST}
                   COMMAND ${arg_TEST}
                   NUM_MPI_TASKS ${arg_NUM_MPI_TASKS})
-                  
+
     ###########################################################################
     # Newer versions of OpenMPI require OMPI_MCA_rmaps_base_oversubscribe=1
     # to run with more tasks than actual cores
@@ -150,7 +150,7 @@ endfunction()
 ## add_python_test( TEST test)
 ##------------------------------------------------------------------------------
 function(add_python_test TEST)
-            
+
     message(STATUS " [*] Adding Python-based Unit Test: ${TEST}")
     add_test( NAME ${TEST}
               COMMAND ${PYTHON_EXECUTABLE} -B -m unittest -v ${TEST})
@@ -176,8 +176,8 @@ function(add_python_mpi_test TEST)
 
     # parse our arguments
     cmake_parse_arguments(arg
-                         "${options}" 
-                         "${singleValueArgs}" 
+                         "${options}"
+                         "${singleValueArgs}"
                          "${multiValueArgs}" ${ARGN} )
 
     message(STATUS " [*] Adding Python-based MPI Unit Test: ${TEST}")
@@ -214,8 +214,8 @@ macro(add_fortran_test)
 
     # parse our arguments
     cmake_parse_arguments(arg
-                         "${options}" 
-                         "${singleValueArgs}" 
+                         "${options}"
+                         "${singleValueArgs}"
                          "${multiValueArgs}" ${ARGN} )
 
     message(STATUS " [*] Adding Fortran Unit Test: ${arg_TEST}")

--- a/src/cmake/thirdparty/SetupADIOS.cmake
+++ b/src/cmake/thirdparty/SetupADIOS.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ###############################################################################
@@ -65,7 +65,7 @@ set(ENV{ADIOS_ROOT} ${ADIOS_ROOT})
 include(${ADIOS_DIR}/etc/FindADIOS.cmake)
 
 # FindADIOS sets ADIOS_DIR to it's installed CMake info if it exists
-# we want to keep ADIOS_DIR as the root dir of the install to be 
+# we want to keep ADIOS_DIR as the root dir of the install to be
 # consistent with other packages
 
 set(ADIOS_DIR ${ADIOS_ROOT} CACHE PATH "" FORCE)

--- a/src/cmake/thirdparty/SetupConduit.cmake
+++ b/src/cmake/thirdparty/SetupConduit.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ###############################################################################
@@ -47,7 +47,7 @@
 # This file defines:
 #  CONDUIT_FOUND - If Conduit was found
 #  CONDUIT_INCLUDE_DIRS - The Conduit include directories
-#  
+#
 #  If found, the conduit CMake targets will also be imported
 ###############################################################################
 
@@ -69,7 +69,7 @@ if(FORTRAN_FOUND)
         message(FATAL_ERROR "Failed to find conduit fortran module. \
                              Ascent Fortran support requires Conduit with Fortran enabled.")
     endif()
-endif() 
+endif()
 
 
 if(EXISTS ${CONDUIT_DIR}/include/conduit/conduit_relay_hdf5_api.hpp)
@@ -107,19 +107,19 @@ if(PYTHON_FOUND)
                                     ERROR_VARIABLE  _FIND_CONDUIT_PYTHON_ERROR_VALUE
                                     OUTPUT_STRIP_TRAILING_WHITESPACE)
             if(_FIND_CONDUIT_PYTHON_RESULT MATCHES 0)
-                # we will use this to make sure we can setup tests correctly 
+                # we will use this to make sure we can setup tests correctly
                 set(EXTRA_PYTHON_MODULE_DIRS "${CONDUIT_DIR}/python-modules/")
                 message(STATUS "FOUND conduit python module at: ${_FIND_CONDUIT_PYTHON_OUT}")
             else()
                 message(FATAL_ERROR
                 "conduit python import failure:\n${_FIND_CONDUIT_PYTHON_OUT}")
-                
+
             endif()
         endif()
     else()
         message(FATAL_ERROR "PYTHON_FOUND = TRUE, but could not find a python interpreter.")
     endif()
-    
+
     set(CONDUIT_PYTHON_INCLUDE_DIR ${_FIND_CONDUIT_PYTHON_OUT})
     message(STATUS "FOUND conduit python include dir: ${CONDUIT_PYTHON_INCLUDE_DIR}")
     list(APPEND CONDUIT_INCLUDE_DIRS ${CONDUIT_PYTHON_INCLUDE_DIR})
@@ -130,7 +130,7 @@ message(STATUS "CONDUIT_INCLUDE_DIRS = ${CONDUIT_INCLUDE_DIRS}")
 
 
 blt_register_library( NAME conduit
-                      INCLUDES ${CONDUIT_INCLUDE_DIRS} 
+                      INCLUDES ${CONDUIT_INCLUDE_DIRS}
                       LIBRARIES  conduit conduit_relay conduit_blueprint)
 
 # assumes conduit was built with mpi

--- a/src/cmake/thirdparty/SetupHDF5.cmake
+++ b/src/cmake/thirdparty/SetupHDF5.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ###############################################################################
@@ -65,7 +65,7 @@ set(ENV{HDF5_ROOT} ${HDF5_ROOT}/bin)
 include(FindHDF5)
 
 # FindHDF5 sets HDF5_DIR to it's installed CMake info if it exists
-# we want to keep HDF5_DIR as the root dir of the install to be 
+# we want to keep HDF5_DIR as the root dir of the install to be
 # consistent with other packages
 
 set(HDF5_DIR ${HDF5_ROOT} CACHE PATH "" FORCE)

--- a/src/cmake/thirdparty/SetupMFEM.cmake
+++ b/src/cmake/thirdparty/SetupMFEM.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ###############################################################################
@@ -57,7 +57,7 @@ endif()
 MESSAGE(STATUS "Looking for MFEM using MFEM_DIR = ${MFEM_DIR}")
 
 
-# when mfem is built w/o cmake, we can get the details of deps from its 
+# when mfem is built w/o cmake, we can get the details of deps from its
 # config.mk file
 find_path(MFEM_CFG_DIR config.mk
           PATHS ${MFEM_DIR}/share/mfem/
@@ -81,7 +81,7 @@ string(FIND  ${mfem_tpl_inc_flags} "\n" mfem_tpl_inc_flags_end_pos)
 string(SUBSTRING ${mfem_tpl_inc_flags} 0 ${mfem_tpl_inc_flags_end_pos} mfem_tpl_inc_flags)
 string(STRIP ${mfem_tpl_inc_flags} mfem_tpl_inc_flags)
 
-# parse link flags 
+# parse link flags
 string(REGEX MATCHALL "MFEM_EXT_LIBS .+\n" mfem_tpl_lnk_flags ${mfem_cfg_file_txt})
 string(REGEX REPLACE  "MFEM_EXT_LIBS +=" "" mfem_tpl_lnk_flags ${mfem_tpl_lnk_flags})
 string(FIND  ${mfem_tpl_lnk_flags} "\n" mfem_tpl_lnl_flags_end_pos )

--- a/src/cmake/thirdparty/SetupPython.cmake
+++ b/src/cmake/thirdparty/SetupPython.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 
@@ -50,43 +50,43 @@ endif()
 
 find_package(PythonInterp REQUIRED)
 if(PYTHONINTERP_FOUND)
-        
+
         MESSAGE(STATUS "PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE}")
-        
-        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" 
+
+        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
                                 "import sys;from distutils.sysconfig import get_python_inc;sys.stdout.write(get_python_inc())"
                         OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
                         ERROR_VARIABLE ERROR_FINDING_INCLUDES)
         MESSAGE(STATUS "PYTHON_INCLUDE_DIR ${PYTHON_INCLUDE_DIR}")
 
-        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" 
+        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
                                 "import sys;from distutils.sysconfig import get_python_lib;sys.stdout.write(get_python_lib())"
                         OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_DIR
                         ERROR_VARIABLE ERROR_FINDING_SITE_PACKAGES_DIR)
         MESSAGE(STATUS "PYTHON_SITE_PACKAGES_DIR ${PYTHON_SITE_PACKAGES_DIR}")
 
-        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" 
+        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
                                 "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBDIR'))"
                         OUTPUT_VARIABLE PYTHON_LIB_DIR
                         ERROR_VARIABLE ERROR_FINDING_LIB_DIR)
         MESSAGE(STATUS "PYTHON_LIB_DIR ${PYTHON_LIB_DIR}")
-        
+
         # check for python libs differs for windows python installs
         if(NOT WIN32)
             set(PYTHON_GLOB_TEST "${PYTHON_LIB_DIR}/libpython*")
         else()
             set(PYTHON_GLOB_TEST "${PYTHON_LIB_DIR}/python*.lib")
         endif()
-            
+
         FILE(GLOB PYTHON_GLOB_RESULT ${PYTHON_GLOB_TEST})
         get_filename_component(PYTHON_LIBRARY "${PYTHON_GLOB_RESULT}" ABSOLUTE)
         MESSAGE(STATUS "{PythonLibs from PythonInterp} using: PYTHON_LIBRARY=${PYTHON_LIBRARY}")
         find_package(PythonLibs)
-        
+
         if(NOT PYTHONLIBS_FOUND)
             MESSAGE(FATAL_ERROR "Failed to find Python Libraries using PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
         endif()
-        
+
 endif()
 
 
@@ -110,7 +110,7 @@ FUNCTION(PYTHON_ADD_DISTUTILS_SETUP target_name
             DEPENDS  ${setup_file} ${ARGN}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-    add_custom_target(${target_name} ALL DEPENDS 
+    add_custom_target(${target_name} ALL DEPENDS
                       ${CMAKE_CURRENT_BINARY_DIR}/${target_name}_build)
 
     # also use distutils for the install ...
@@ -137,14 +137,14 @@ FUNCTION(PYTHON_ADD_DISTUTILS_SETUP target_name
             MESSAGE(STATUS \"\${PY_DIST_UTILS_INSTALL_OUT}\")
             ")
     endif()
-    
+
 ENDFUNCTION(PYTHON_ADD_DISTUTILS_SETUP)
 
 ##############################################################################
-# Macro to create a compiled python module 
+# Macro to create a compiled python module
 ##############################################################################
 #
-# we use this instead of the std ADD_PYTHON_MODULE cmake command 
+# we use this instead of the std ADD_PYTHON_MODULE cmake command
 # to setup proper install targets.
 #
 ##############################################################################
@@ -161,7 +161,7 @@ FUNCTION(PYTHON_ADD_COMPILED_MODULE target_name
     target_link_libraries(${target_name} ${PYTHON_LIBRARIES})
 
     # support installing the python module components to an
-    # an alternate dir, set via PYTHON_MODULE_INSTALL_PREFIX 
+    # an alternate dir, set via PYTHON_MODULE_INSTALL_PREFIX
     set(py_install_dir ${dest_dir})
     if(PYTHON_MODULE_INSTALL_PREFIX)
         set(py_install_dir ${PYTHON_MODULE_INSTALL_PREFIX})
@@ -199,7 +199,7 @@ FUNCTION(PYTHON_ADD_HYBRID_MODULE target_name
     target_link_libraries(${target_name} ${PYTHON_LIBRARIES})
 
     # support installing the python module components to an
-    # an alternate dir, set via PYTHON_MODULE_INSTALL_PREFIX 
+    # an alternate dir, set via PYTHON_MODULE_INSTALL_PREFIX
     set(py_install_dir ${dest_dir})
     if(PYTHON_MODULE_INSTALL_PREFIX)
         set(py_install_dir ${PYTHON_MODULE_INSTALL_PREFIX})
@@ -215,8 +215,8 @@ FUNCTION(PYTHON_ADD_HYBRID_MODULE target_name
 ENDFUNCTION(PYTHON_ADD_HYBRID_MODULE)
 
 #
-# Also register python as a BLT dep,to support the case were we link python, 
-# as opposed to creating python modules via the above macros. 
+# Also register python as a BLT dep,to support the case were we link python,
+# as opposed to creating python modules via the above macros.
 #
 
 blt_register_library(NAME python

--- a/src/cmake/thirdparty/SetupVTKh.cmake
+++ b/src/cmake/thirdparty/SetupVTKh.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 if(NOT VTKH_DIR)
@@ -56,7 +56,7 @@ message(STATUS "Found VTKh include dirs: ${VTKh_INCLUDE_DIRS}")
 set(VTKH_FOUND TRUE)
 
 
-blt_register_library(NAME vtkh 
+blt_register_library(NAME vtkh
                      INCLUDES ${VTKh_INCLUDE_DIRS}
                      LIBRARIES vtkh)
 

--- a/src/cmake/thirdparty/SetupVTKm.cmake
+++ b/src/cmake/thirdparty/SetupVTKm.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-716457
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Ascent. 
-# 
+#
+# This file is part of Ascent.
+#
 # For details, see: http://ascent.readthedocs.io/.
-# 
+#
 # Please also read ascent/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 ###############################################################################


### PR DESCRIPTION
- Removing trailing whitespace in CMake files.
- Correcting type of cached variables set in CMake. In particular, those that
  should be booleans with a value of OFF/ON.