### PR TITLE
update uberenv and add spack env helper

### DIFF
--- a/scripts/gen_spack_env_script.py
+++ b/scripts/gen_spack_env_script.py
@@ -1,0 +1,108 @@
+###############################################################################
+# Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+# 
+# Produced at the Lawrence Livermore National Laboratory
+# 
+# LLNL-CODE-716457
+# 
+# All rights reserved.
+# 
+# This file is part of Ascent. 
+# 
+# For details, see: http://ascent.readthedocs.io/.
+# 
+# Please also read ascent/LICENSE
+# 
+# Redistribution and use in source and binary forms, with or without 
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, 
+#   this list of conditions and the disclaimer below.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the
+#   documentation and/or other materials provided with the distribution.
+# 
+# * Neither the name of the LLNS/LLNL nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+# LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# POSSIBILITY OF SUCH DAMAGE.
+# 
+###############################################################################
+import os
+import sys
+import subprocess
+
+from os.path import join as pjoin
+
+#
+# Looks for subdir: spack or uberenv_libs/spack
+# queries spack for given package names and 
+# creates a bash script that adds those to your path
+#
+# usage:
+# python gen_spack_env_script.py [spack_pkg_1 spack_pkg_2 ...]
+#
+
+def sexe(cmd,ret_output=False,echo = False):
+    """ Helper for executing shell commands. """
+    if echo:
+        print "[exe: %s]" % cmd
+    if ret_output:
+        p = subprocess.Popen(cmd,
+                             shell=True,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        res =p.communicate()[0]
+        return p.returncode,res
+    else:
+        return subprocess.call(cmd,shell=True)
+
+
+def spack_exe(spath=None):
+    if spath is None:
+        to_try = [pjoin("uberenv_libs","spack"), "spack"]
+        for p in to_try:
+            if os.path.isdir(p):
+                return os.path.abspath(pjoin(p,"bin","spack"))
+    else:
+        return os.path.abspath(spath,"bin","spack")
+
+def find_pkg(pkg_name):
+    r,rout = sexe(spack_exe() + " find -p " + pkg_name,ret_output = True)
+    for l in rout.split("\n"):
+        if l.startswith(" "):
+            return {"name": pkg_name, "path": l.split()[-1]}
+
+def path_cmd(pkg):
+    return 'export PATH=%s:$PATH\n' % (pjoin(pkg["path"],"bin"))
+
+def write_env_script(pkgs):
+    ofile = open("s_env.sh","w")
+    for p in pkgs:
+        print "[found %s at %s]" % (p["name"],p["path"])
+        ofile.write("# %s\n" % p["name"])
+        ofile.write(path_cmd(p))
+    print "[created %s]" % (os.path.abspath("s_env.sh"))
+
+def main():
+    pkgs = [find_pkg(pkg) for pkg in sys.argv[1:]]
+    if len(pkgs) > 0:
+        write_env_script(pkgs)
+    else:
+        print "[error, did not find any packages]"
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uberenv/uberenv.py
+++ b/scripts/uberenv/uberenv.py
@@ -139,6 +139,16 @@ def parse_args():
                       default=False,
                       help="Pull if spack repo already exists")
 
+    # option to force a spack pull
+    parser.add_option("--macos-sdk-env-setup",
+                      action="store_true",
+                      dest="macos_sdk_env_setup",
+                      default=False,
+                      help="Set several env vars to select OSX SDK settings."
+                           "This was necessary for older versions of macOS "
+                           " but can cause issues with macOS versions >= 10.13. "
+                           " so it is disabled by default.")
+
 
     ###############
     # parse args
@@ -349,7 +359,10 @@ def main():
     # setup osx deployment target
     print "[uberenv options: %s]" % str(opts)
     if "darwin" in platform.system().lower():
-        setup_osx_sdk_env_vars()
+        if opts["macos_sdk_env_setup"]:
+            setup_osx_sdk_env_vars()
+        else:
+            print "[skipping MACOSX env var setup]"
     # setup default spec
     if opts["spec"] is None:
         if "darwin" in platform.system().lower():


### PR DESCRIPTION
Adds a new option to uberenv for setting macOS sdk.

In this past, this was always done b/c of issues on older version of macOS

However on newer macOS versions this causes problems. So it is now an option that is disabled by default. 

This should resolve #165 
