### PR TITLE
fix clobber of python env set for mpi c++ tests

### DIFF
--- a/src/cmake/SetupTests.cmake
+++ b/src/cmake/SetupTests.cmake
@@ -212,7 +212,7 @@ function(add_cpp_mpi_test)
     # with other mpi implementations.
     ###########################################################################
     set_property(TEST ${arg_TEST}
-                 PROPERTY ENVIRONMENT  "OMPI_MCA_rmaps_base_oversubscribe=1")
+                 APPEND PROPERTY ENVIRONMENT  "OMPI_MCA_rmaps_base_oversubscribe=1")
 endfunction()
 
 


### PR DESCRIPTION
fix issue with mpi py ascent inception tests, caught on osx