### PR TITLE
Task/keep graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Ascent Changelog
+Notable changes to Ascent are documented in this file. This changlog started on 8/12/19 and does not document prior changes.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project aspires to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+#### General
+- Deprecated the `execute` and `reset` actions. `ascent.execute(actions)` now implicitly resets and execute the Ascent actions. To maintain a degree of backwards compatibility, using `execute` and `reset` are still passable to `ascent.execute(actions)`. Internally, the internal data flow network will only be rebuilt when the current actions differ from the previously executed actions. Note: this only occurs when the Ascent runtime object is persistent between calls to `ascent.execute(actions)`.
+- Added support for YAML `ascent_actions` and `ascent_options` files. YAML files are much easier for humans to compose.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ http://ascent.readthedocs.io/en/latest/Licenses.html
 
 or the following files in the Ascent source tree:
 - [LICENSE](/LICENSE)
+
+Changelog
+=========
+- [Changelog](/CHANGELOG.md)

--- a/src/ascent/runtimes/ascent_main_runtime.cpp
+++ b/src/ascent/runtimes/ascent_main_runtime.cpp
@@ -1222,9 +1222,6 @@ AscentRuntime::BuildGraph(const conduit::Node &actions)
   conduit::Node scenes;
   conduit::Node extracts;
 
-  bool do_execute = false;
-  bool do_reset= false;
-
   // Loop over the actions
   for (int i = 0; i < actions.number_of_children(); ++i)
   {
@@ -1286,13 +1283,12 @@ AscentRuntime::BuildGraph(const conduit::Node &actions)
           ASCENT_ERROR("action 'add_queries' missing child 'queries'");
         }
       }
-      else if( action_name == "execute")
+      else if( action_name == "execute" ||
+               action_name == "reset")
       {
-        do_execute = true;
-      }
-      else if( action_name == "reset")
-      {
-        do_reset = true;
+        // These actions are now deprecated. To avoid
+        // issues with existing integrations we will just
+        // do nothing
       }
       else
       {

--- a/src/ascent/runtimes/ascent_main_runtime.hpp
+++ b/src/ascent/runtimes/ascent_main_runtime.hpp
@@ -103,6 +103,7 @@ private:
     conduit::Node     m_scene_connections;
 
     conduit::Node     m_info;
+    conduit::Node     m_previous_actions;
 
     WebInterface      m_web_interface;
     int               m_refinement_level;
@@ -133,7 +134,8 @@ private:
     void ConvertSceneToFlow(const conduit::Node &scenes);
     void ConnectSource();
     void ConnectGraphs();
-    void ExecuteGraphs();
+
+    void BuildGraph(const conduit::Node &actions);
     void EnsureDomainIds();
     void PopulateMetadata();
 

--- a/src/examples/actions_json/contour.py
+++ b/src/examples/actions_json/contour.py
@@ -24,10 +24,6 @@ add_scene = actions.append()
 add_scene["action"] = "add_scenes"
 add_scene["scenes"] = scenes
 
-# execute and reset the actions
-actions.append()["action"] = "execute"
-actions.append()["action"] = "reset"
-
 # save example actions to a json and yaml file
 actions.save("ascent_actions.json",protocol="json")
 actions.save("ascent_actions.yaml",protocol="yaml")

--- a/src/examples/actions_json/renders.py
+++ b/src/examples/actions_json/renders.py
@@ -96,10 +96,6 @@ add_scene = actions.append()
 add_scene["action"] = "add_scenes"
 add_scene["scenes"] = scenes
 
-# execute and reset the actions
-actions.append()["action"] = "execute"
-actions.append()["action"] = "reset"
-
 # save example actions to a json and yaml file
 actions.save("ascent_actions.json",protocol="json")
 actions.save("ascent_actions.yaml",protocol="yaml")

--- a/src/examples/paraview-vis/ascent_actions.json
+++ b/src/examples/paraview-vis/ascent_actions.json
@@ -12,13 +12,6 @@
          }
        }
     }
-  },
-
-  {
-    "action": "execute"
-  },
-
-  {
-    "action": "reset"
   }
+
 ]

--- a/src/examples/paraview-vis/ascent_actions.yaml
+++ b/src/examples/paraview-vis/ascent_actions.yaml
@@ -1,12 +1,8 @@
 
-- 
+-
   action: "add_extracts"
-  extracts: 
-    e1: 
+  extracts:
+    e1:
       type: "python"
-      params: 
+      params:
         file: "paraview-vis.py"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/proxies/cloverleaf3d-ref/CMakeLists.txt
+++ b/src/examples/proxies/cloverleaf3d-ref/CMakeLists.txt
@@ -101,8 +101,8 @@ set(clover_sources
 if(MPI_FOUND AND FORTRAN_FOUND)
     # copy over the input deck
     configure_file(clover.in ${CMAKE_CURRENT_BINARY_DIR}/clover.in COPYONLY)
-    configure_file(ascent_actions.json ${CMAKE_CURRENT_BINARY_DIR}/ascent_actions.json COPYONLY)
-    configure_file(ascent_options.json ${CMAKE_CURRENT_BINARY_DIR}/ascent_options.json COPYONLY)
+    configure_file(ascent_actions.yaml ${CMAKE_CURRENT_BINARY_DIR}/ascent_actions.yaml COPYONLY)
+    configure_file(ascent_options.yaml ${CMAKE_CURRENT_BINARY_DIR}/ascent_options.yaml COPYONLY)
 
     if(MPI_Fortran_USE_MODULE )
         set(clover_compile_flags "-DUSE_MOD")

--- a/src/examples/proxies/cloverleaf3d-ref/ascent_actions.json
+++ b/src/examples/proxies/cloverleaf3d-ref/ascent_actions.json
@@ -15,13 +15,5 @@
         }
       }
     }
-  },
-
-  {
-    "action": "execute"
-  },
-
-  {
-    "action": "reset"
   }
 ]

--- a/src/examples/proxies/cloverleaf3d-ref/ascent_actions.yaml
+++ b/src/examples/proxies/cloverleaf3d-ref/ascent_actions.yaml
@@ -1,13 +1,8 @@
-
-- 
+-
   action: "add_scenes"
-  scenes: 
-    s1: 
-      plots: 
-        p1: 
+  scenes:
+    s1:
+      plots:
+        p1:
           type: "volume"
           field: "energy"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/proxies/cloverleaf3d-ref/visit.F90
+++ b/src/examples/proxies/cloverleaf3d-ref/visit.F90
@@ -197,12 +197,6 @@ SUBROUTINE visit(my_ascent)
       CALL conduit_node_set_path_char8_str(scenes,"s1/plots/p1/type", "volume")
       CALL conduit_node_set_path_char8_str(scenes,"s1/plots/p1/field", "energy")
 
-      execute_act = conduit_node_append(sim_actions)
-      CALL conduit_node_set_path_char8_str(execute_act,"action", "execute")
-
-      reset_act = conduit_node_append(sim_actions)
-      CALL conduit_node_set_path_char8_str(reset_act,"action", "reset")
-
       CALL ascent_publish(my_ascent, sim_data)
       CALL ascent_execute(my_ascent, sim_actions)
 

--- a/src/examples/proxies/kripke/CMakeLists.txt
+++ b/src/examples/proxies/kripke/CMakeLists.txt
@@ -79,8 +79,8 @@ if(MPI_FOUND)
     configure_file(run_kripke_simple_example.sh
                    ${CMAKE_CURRENT_BINARY_DIR}/run_kripke_simple_example.sh
                    COPYONLY)
-    configure_file(ascent_actions.json ${CMAKE_CURRENT_BINARY_DIR}/ascent_actions.json COPYONLY)
-    configure_file(ascent_options.json ${CMAKE_CURRENT_BINARY_DIR}/ascent_options.json COPYONLY)
+    configure_file(ascent_actions.yaml ${CMAKE_CURRENT_BINARY_DIR}/ascent_actions.yaml COPYONLY)
+    configure_file(ascent_options.yaml ${CMAKE_CURRENT_BINARY_DIR}/ascent_options.yaml COPYONLY)
 
     if(ENABLE_OPENMP)
        set(kripke_openmp_flags "-DKRIPKE_USE_OPENMP")

--- a/src/examples/proxies/kripke/ascent_actions.json
+++ b/src/examples/proxies/kripke/ascent_actions.json
@@ -16,14 +16,6 @@
         }
       }
     }
-  },
-
-  {
-    "action": "execute"
-  },
-
-  {
-    "action": "reset"
   }
 ]
 

--- a/src/examples/proxies/kripke/ascent_actions.yaml
+++ b/src/examples/proxies/kripke/ascent_actions.yaml
@@ -1,13 +1,9 @@
 
-- 
+-
   action: "add_scenes"
-  scenes: 
-    s1: 
-      plots: 
-        p1: 
+  scenes:
+    s1:
+      plots:
+        p1:
           type: "volume"
           field: "phi"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/proxies/laghos/CMakeLists.txt
+++ b/src/examples/proxies/laghos/CMakeLists.txt
@@ -27,7 +27,7 @@ file(COPY run_tripple_point_3d.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY run_sedov_2d.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY run_sedov_3d.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 # copy example laucnh scripts
-file(COPY ascent_options.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY ascent_options.yaml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # mfem does not build with both serial and mpi
 if(MPI_FOUND AND ENABLE_MPI)

--- a/src/examples/proxies/laghos/laghos.cpp
+++ b/src/examples/proxies/laghos/laghos.cpp
@@ -551,11 +551,6 @@ int main(int argc, char *argv[])
             conduit::Node &add_plots = actions.append();
             add_plots["action"] = "add_scenes";
             add_plots["scenes"] = scenes;
-            conduit::Node &execute = actions.append();
-            execute["action"] = "execute";
-
-            conduit::Node &reset = actions.append();
-            reset["action"] = "reset";
 
             ascent.execute(actions);
 

--- a/src/examples/proxies/lulesh2.0.3/CMakeLists.txt
+++ b/src/examples/proxies/lulesh2.0.3/CMakeLists.txt
@@ -55,8 +55,8 @@ set(LULESH_SOURCES
     lulesh-util.cc
     lulesh-init.cc)
 
-configure_file(ascent_actions.json ${CMAKE_CURRENT_BINARY_DIR}/ascent_actions.json COPYONLY)
-configure_file(ascent_options.json ${CMAKE_CURRENT_BINARY_DIR}/ascent_options.json COPYONLY)
+configure_file(ascent_actions.yaml ${CMAKE_CURRENT_BINARY_DIR}/ascent_actions.yaml COPYONLY)
+configure_file(ascent_options.yaml ${CMAKE_CURRENT_BINARY_DIR}/ascent_options.yaml COPYONLY)
 
 set(lulesh_deps ascent)
 

--- a/src/examples/proxies/lulesh2.0.3/ascent_actions.json
+++ b/src/examples/proxies/lulesh2.0.3/ascent_actions.json
@@ -16,11 +16,5 @@
         "image_prefix": "energy_%04d"
       }
     }
-  },
-  {
-    "action": "execute"
-  },
-  {
-    "action": "reset"
   }
 ]

--- a/src/examples/proxies/lulesh2.0.3/ascent_actions.yaml
+++ b/src/examples/proxies/lulesh2.0.3/ascent_actions.yaml
@@ -1,14 +1,10 @@
 
-- 
+-
   action: "add_scenes"
-  scenes: 
-    s1: 
-      plots: 
-        p1: 
+  scenes:
+    s1:
+      plots:
+        p1:
           type: "pseudocolor"
           field: "e"
       image_prefix: "energy_%04d"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/python/ascent_python_mpi_render_example.py
+++ b/src/examples/python/ascent_python_mpi_render_example.py
@@ -103,8 +103,6 @@ add_act =actions.append()
 add_act["action"] = "add_scenes"
 add_act["scenes"] = scenes
 
-actions.append()["action"] = "execute"
-
 # execute
 a.execute(actions)
 

--- a/src/examples/python/ascent_python_render_example.py
+++ b/src/examples/python/ascent_python_render_example.py
@@ -87,8 +87,6 @@ add_act =actions.append()
 add_act["action"] = "add_scenes"
 add_act["scenes"] = scenes
 
-actions.append()["action"] = "execute"
-
 # execute
 a.execute(actions)
 

--- a/src/examples/synthetic/noise/ASCENT_README.md
+++ b/src/examples/synthetic/noise/ASCENT_README.md
@@ -20,3 +20,7 @@ mpiexec -n 2 ./noise_par
 For more info, please visit:
 
 http://ascent.readthedocs.io/en/latest/ExampleIntegrations.html
+
+By default, noise will generate images of a scene with a isosurface and a volume plot.
+Additionally, we include the `example_actions.yaml` file containing another set of actions.
+To enable the actions decribed in the file, rename it to `ascent_actions.yaml`.

--- a/src/examples/synthetic/noise/CMakeLists.txt
+++ b/src/examples/synthetic/noise/CMakeLists.txt
@@ -108,6 +108,7 @@ if(MPI_FOUND)
 endif()
 
 
+configure_file(example_actions.yaml ${CMAKE_CURRENT_BINARY_DIR}/example_actions.yaml COPYONLY)
 
 
 

--- a/src/examples/synthetic/noise/example_actions.yaml
+++ b/src/examples/synthetic/noise/example_actions.yaml
@@ -1,0 +1,18 @@
+-
+  action: "add_pipelines"
+  pipelines:
+    p1:
+      f1:
+        type: "contour"
+        params:
+          field: "nodal_noise"
+          levels: 5
+-
+  action: "add_scenes"
+  scenes:
+    s1:
+      plots:
+        p1:
+          type: "pseudocolor"
+          field: "zonal_noise"
+          pipeline: "p1"

--- a/src/examples/synthetic/noise/noise.cpp
+++ b/src/examples/synthetic/noise/noise.cpp
@@ -509,12 +509,6 @@ int main(int argc, char** argv)
   add_scenes["action"] = "add_scenes";
   add_scenes["scenes"] = scenes;
 
-  conduit::Node &execute = actions.append();
-  execute["action"] = "execute";
-
-  conduit::Node reset;
-  conduit::Node &reset_action = reset.append();
-  reset_action["action"] = "reset";
   for(int t = 0; t < options.m_time_steps; ++t)
   {
     //
@@ -546,7 +540,6 @@ int main(int argc, char** argv)
 
         ascent.publish(mesh_data);
         ascent.execute(actions);
-        ascent.execute(reset);
       } //for each time step
 
 

--- a/src/examples/tutorial/demo_2/contour.json
+++ b/src/examples/tutorial/demo_2/contour.json
@@ -34,12 +34,5 @@
          }
        }
      }
-   },
-   {
-     "action": "execute"
-   },
-
-   {
-     "action": "reset"
    }
 ]

--- a/src/examples/tutorial/demo_2/contour.yaml
+++ b/src/examples/tutorial/demo_2/contour.yaml
@@ -1,23 +1,19 @@
 
-- 
+-
   action: "add_pipelines"
-  pipelines: 
-    pl1: 
-      f1: 
+  pipelines:
+    pl1:
+      f1:
         type: "contour"
-        params: 
+        params:
           field: "velocity_x"
           iso_values: 1.0
-- 
+-
   action: "add_scenes"
-  scenes: 
-    scene1: 
-      plots: 
-        plt1: 
+  scenes:
+    scene1:
+      plots:
+        plt1:
           type: "pseudocolor"
           pipeline: "pl1"
           field: "pressure"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/tutorial/demo_2/volume_contour.json
+++ b/src/examples/tutorial/demo_2/volume_contour.json
@@ -39,12 +39,5 @@
          }
        }
      }
-   },
-   {
-     "action": "execute"
-   },
-
-   {
-     "action": "reset"
    }
 ]

--- a/src/examples/tutorial/demo_2/volume_contour.yaml
+++ b/src/examples/tutorial/demo_2/volume_contour.yaml
@@ -1,26 +1,22 @@
 
-- 
+-
   action: "add_pipelines"
-  pipelines: 
-    pl1: 
-      f1: 
+  pipelines:
+    pl1:
+      f1:
         type: "contour"
-        params: 
+        params:
           field: "velocity_x"
           iso_values: 1.0
-- 
+-
   action: "add_scenes"
-  scenes: 
-    scene1: 
-      plots: 
-        plt1: 
+  scenes:
+    scene1:
+      plots:
+        plt1:
           type: "pseudocolor"
           pipeline: "pl1"
           field: "pressure"
-        plt2: 
+        plt2:
           type: "volume"
           field: "energy"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/tutorial/demo_3/ascent_actions.json
+++ b/src/examples/tutorial/demo_3/ascent_actions.json
@@ -27,13 +27,5 @@
         }
       }
     }
-  },
-
-  {
-    "action": "execute"
-  },
-
-  {
-    "action": "reset"
   }
 ]

--- a/src/examples/tutorial/demo_3/ascent_actions.yaml
+++ b/src/examples/tutorial/demo_3/ascent_actions.yaml
@@ -1,21 +1,17 @@
 
-- 
+-
   action: "add_scenes"
-  scenes: 
-    s1: 
-      plots: 
-        p1: 
+  scenes:
+    s1:
+      plots:
+        p1:
           type: "volume"
           field: "energy"
           min_value: 1
           max_value: 3
-      renders: 
-        r1: 
+      renders:
+        r1:
           type: "cinema"
           phi: 4
           theta: 4
           db_name: "clover_db"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/tutorial/demo_4/ascent_actions.json
+++ b/src/examples/tutorial/demo_4/ascent_actions.json
@@ -12,13 +12,5 @@
          }
        }
     }
-  },
-
-  {
-    "action": "execute"
-  },
-
-  {
-    "action": "reset"
   }
 ]

--- a/src/examples/tutorial/demo_4/ascent_actions.yaml
+++ b/src/examples/tutorial/demo_4/ascent_actions.yaml
@@ -1,12 +1,8 @@
 
-- 
+-
   action: "add_extracts"
-  extracts: 
-    e1: 
+  extracts:
+    e1:
       type: "python"
-      params: 
+      params:
         file: "ascent_tutorial_demo_4_histogram.py"
-- 
-  action: "execute"
-- 
-  action: "reset"

--- a/src/examples/tutorial/ecp_2019/ascent_example1.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_example1.cpp
@@ -35,8 +35,6 @@ int main(int argc, char **argv)
     add_act["action"] = "add_scenes";
     add_act["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_extract_example1.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_extract_example1.cpp
@@ -33,8 +33,6 @@ int main(int argc, char **argv)
     add_act["action"] = "add_extracts";
     add_act["extracts"] = extracts;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_extract_example2.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_extract_example2.cpp
@@ -47,8 +47,6 @@ int main(int argc, char **argv)
     add_act2["action"] = "add_extracts";
     add_act2["extracts"] = extracts;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_pipeline_example1.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_pipeline_example1.cpp
@@ -48,8 +48,6 @@ int main(int argc, char **argv)
     add_act2["action"] = "add_scenes";
     add_act2["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_pipeline_example2.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_pipeline_example2.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     thresh_params["min_value"] = 0.0;
     thresh_params["max_value"] = 0.5;
     pipelines["pl1/f1/params"] = thresh_params;
-    
+
     pipelines["pl1/f2/type"]   = "clip";
     // filter parameters
     conduit::Node clip_params;
@@ -60,8 +60,6 @@ int main(int argc, char **argv)
     Node &add_act2 = actions.append();
     add_act2["action"] = "add_scenes";
     add_act2["scenes"] = scenes;
-
-    actions.append()["action"] = "execute";
 
     // execute
     a.execute(actions);

--- a/src/examples/tutorial/ecp_2019/ascent_pipeline_example3.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_pipeline_example3.cpp
@@ -69,8 +69,6 @@ int main(int argc, char **argv)
     add_act2["action"] = "add_scenes";
     add_act2["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_scene_example1.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_scene_example1.cpp
@@ -70,8 +70,6 @@ int main(int argc, char **argv)
     add_act["action"] = "add_scenes";
     add_act["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_scene_example2.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_scene_example2.cpp
@@ -67,8 +67,6 @@ int main(int argc, char **argv)
     add_act["action"] = "add_scenes";
     add_act["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_scene_example3.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_scene_example3.cpp
@@ -69,8 +69,6 @@ int main(int argc, char **argv)
     add_act["action"] = "add_scenes";
     add_act["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/examples/tutorial/ecp_2019/ascent_scene_example4.cpp
+++ b/src/examples/tutorial/ecp_2019/ascent_scene_example4.cpp
@@ -72,8 +72,6 @@ int main(int argc, char **argv)
     add_act["action"] = "add_scenes";
     add_act["scenes"] = scenes;
 
-    actions.append()["action"] = "execute";
-
     // execute
     a.execute(actions);
 

--- a/src/tests/ascent/python/t_python_ascent_mpi_render.py
+++ b/src/tests/ascent/python/t_python_ascent_mpi_render.py
@@ -110,8 +110,6 @@ class Test_Ascent_MPI_Render(unittest.TestCase):
         add_act["action"] = "add_scenes"
         add_act["scenes"] = scenes
 
-        actions.append()["action"] = "execute"
-
         a.execute(actions)
         a.close()
 
@@ -168,8 +166,6 @@ class Test_Ascent_MPI_Render(unittest.TestCase):
         add_act =actions.append()
         add_act["action"] = "add_scenes"
         add_act["scenes"] = scenes
-
-        actions.append()["action"] = "execute"
 
         a.execute(actions)
         a.close()

--- a/src/tests/ascent/python/t_python_ascent_render.py
+++ b/src/tests/ascent/python/t_python_ascent_render.py
@@ -95,8 +95,6 @@ class Test_Ascent_Render(unittest.TestCase):
         add_act["action"] = "add_scenes"
         add_act["scenes"] = scenes
 
-        actions.append()["action"] = "execute"
-
         a.execute(actions)
 
         ascent_info = conduit.Node()
@@ -142,8 +140,6 @@ class Test_Ascent_Render(unittest.TestCase):
         add_act =actions.append()
         add_act["action"] = "add_scenes"
         add_act["scenes"] = scenes
-
-        actions.append()["action"] = "execute"
 
         a.execute(actions)
         a.close()

--- a/src/tests/ascent/t_ascent_ascent_runtime.cpp
+++ b/src/tests/ascent/t_ascent_ascent_runtime.cpp
@@ -103,8 +103,6 @@ TEST(ascent_pipeline, test_render_3d_main_pipeline)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //
@@ -189,9 +187,6 @@ TEST(ascent_pipeline, test_register_extract)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
-
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     Node data, info;
     conduit::blueprint::mesh::examples::braid("quads",
@@ -295,10 +290,6 @@ TEST(ascent_pipeline, test_register_transform)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
 
     Ascent ascent;
     EXPECT_TRUE(conduit::blueprint::mesh::verify(data,info));

--- a/src/tests/ascent/t_ascent_cinema_a.cpp
+++ b/src/tests/ascent/t_ascent_cinema_a.cpp
@@ -120,8 +120,6 @@ TEST(ascent_cinema_a, test_cinema_a)
     conduit::Node &add_scenes = actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //

--- a/src/tests/ascent/t_ascent_clip.cpp
+++ b/src/tests/ascent/t_ascent_clip.cpp
@@ -139,9 +139,6 @@ TEST(ascent_clip, test_clip_sphere)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -230,9 +227,6 @@ TEST(ascent_clip, test_clip_inverted_sphere)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -321,9 +315,6 @@ TEST(ascent_clip, test_clip_box)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -413,9 +404,6 @@ TEST(ascent_clip, test_clip_plane)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_clip_with_field.cpp
+++ b/src/tests/ascent/t_ascent_clip_with_field.cpp
@@ -135,9 +135,6 @@ TEST(ascent_clip_with_field, test_clip_with_field)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -220,9 +217,6 @@ TEST(ascent_clip_with_field, test_clip_with_field_inverted)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_contour.cpp
+++ b/src/tests/ascent/t_ascent_contour.cpp
@@ -135,9 +135,6 @@ TEST(ascent_contour, test_single_contour_3d)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -220,9 +217,6 @@ TEST(ascent_contour, test_multi_contour_3d)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -304,9 +298,6 @@ TEST(ascent_contour, test_multi_contour_levels)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_error_handling.cpp
+++ b/src/tests/ascent/t_ascent_error_handling.cpp
@@ -136,9 +136,6 @@ TEST(ascent_error_handling, test_bad_filter_field)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -230,9 +227,6 @@ TEST(ascent_error_handling, test_bad_plot_var_name)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -311,9 +305,6 @@ TEST(ascent_error_handling, test_bad_color_table)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -408,9 +399,6 @@ TEST(ascent_error_handling, test_emtpy)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_hola.cpp
+++ b/src/tests/ascent/t_ascent_hola.cpp
@@ -105,9 +105,6 @@ TEST(ascent_hola, test_hola_relay_blueprint_mesh)
     add_extract["extracts/e1/params/path"] = output_file;
     add_extract["extracts/e1/params/protocol"] = "blueprint/mesh/hdf5";
 
-    actions.append()["action"] = "execute";
-    actions.print();
-
     //
     // Run Ascent
     //

--- a/src/tests/ascent/t_ascent_hola_mpi.cpp
+++ b/src/tests/ascent/t_ascent_hola_mpi.cpp
@@ -286,7 +286,6 @@ TEST(ascent_hola_mpi, test_hola_mpi)
         add_extract["extracts/e1/type"]  = "hola_mpi";
         add_extract["extracts/e1/params/mpi_comm"] = MPI_Comm_c2f(world_comm);
         add_extract["extracts/e1/params/rank_split"] = rank_split;
-        actions.append()["action"] = "execute";
         //
         // Run Ascent
         //
@@ -341,9 +340,6 @@ TEST(ascent_hola_mpi, test_hola_mpi)
         add_scene["scenes/scene1/plots/plt1/type"]         = "pseudocolor";
         add_scene["scenes/scene1/plots/plt1/field"] = "radial_vert";
         add_scene["scenes/scene1/image_prefix"] = output_image;
-
-        conduit::Node &execute  = actions.append();
-        execute["action"] = "execute";
 
         ascent.publish(data);
         ascent.execute(actions);

--- a/src/tests/ascent/t_ascent_image_compare.cpp
+++ b/src/tests/ascent/t_ascent_image_compare.cpp
@@ -119,8 +119,6 @@ TEST(ascent_image_compare, test_image_diff)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //

--- a/src/tests/ascent/t_ascent_iso_volume.cpp
+++ b/src/tests/ascent/t_ascent_iso_volume.cpp
@@ -135,9 +135,6 @@ TEST(ascent_iso_volume, test_iso_volume)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_lagrangian.cpp
+++ b/src/tests/ascent/t_ascent_lagrangian.cpp
@@ -129,12 +129,6 @@ TEST(ascent_lagrangian, test_lagrangian_multistep)
     conduit::Node &add_pipelines = actions.append();
     add_pipelines["action"] = "add_pipelines";
     add_pipelines["pipelines"] = pipelines;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-    // reset
-    conduit::Node &reset  = actions.append();
-    reset["action"] = "reset";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_log.cpp
+++ b/src/tests/ascent/t_ascent_log.cpp
@@ -137,9 +137,6 @@ TEST(ascent_log, test_log)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -220,9 +217,6 @@ TEST(ascent_vector_mag, test_vector_mag_interleaved)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_mpi_adios_extract.cpp
+++ b/src/tests/ascent/t_ascent_mpi_adios_extract.cpp
@@ -139,9 +139,6 @@ TEST(ascent_mpi_runtime, test_render_mpi_2d_main_runtime)
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
 
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
     actions.print();
 
     //

--- a/src/tests/ascent/t_ascent_mpi_ascent_runtime.cpp
+++ b/src/tests/ascent/t_ascent_mpi_ascent_runtime.cpp
@@ -131,10 +131,6 @@ TEST(ascent_mpi_runtime, test_render_mpi_2d_main_runtime)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    // todo add_scene, singular? to simplify
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
 
     actions.print();
 

--- a/src/tests/ascent/t_ascent_mpi_render_3d.cpp
+++ b/src/tests/ascent/t_ascent_mpi_render_3d.cpp
@@ -136,8 +136,6 @@ TEST(ascent_mpi_render_3d, mpi_render_3d_default_runtime)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -199,7 +197,7 @@ TEST(ascent_mpi_render_3d, mpi_render_ranks_without_data)
         // wipe out the data, emulating sims with no data on some mpi tasks
         data.reset();
     }
-    
+
     if(!data.dtype().is_empty())
     {
         conduit::blueprint::mesh::verify(data,verify_info);
@@ -237,8 +235,6 @@ TEST(ascent_mpi_render_3d, mpi_render_ranks_without_data)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -302,8 +298,6 @@ TEST(ascent_mpi_render_3d, mpi_render_no_data)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -321,7 +315,7 @@ TEST(ascent_mpi_render_3d, mpi_render_no_data)
     ascent.publish(data);
     // we expect ascent to complain about no data
     EXPECT_THROW(ascent.execute(actions),conduit::Error);
-    
+
     ascent.close();
 
 }
@@ -398,8 +392,6 @@ TEST(ascent_mpi_render_3d, mpi_render_3d_diy_compositor_volume)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_mpi_slice.cpp
+++ b/src/tests/ascent/t_ascent_mpi_slice.cpp
@@ -153,9 +153,6 @@ TEST(ascent_mpi_slice, mpi_3slice)
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
 
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
     actions.print();
 
     //

--- a/src/tests/ascent/t_ascent_pipelines_to_pipelines.cpp
+++ b/src/tests/ascent/t_ascent_pipelines_to_pipelines.cpp
@@ -138,9 +138,6 @@ TEST(ascent_pipelines_to_pipelines, test_pipelines_to_pipelines)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -221,9 +218,6 @@ TEST(ascent_vector_mag, test_vector_mag_interleaved)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_python_extract.cpp
+++ b/src/tests/ascent/t_ascent_python_extract.cpp
@@ -95,9 +95,6 @@ TEST(ascent_runtime, test_python_script_extract)
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
 
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
     actions.print();
 
     //
@@ -149,9 +146,6 @@ TEST(ascent_runtime, test_python_script_extract_from_file)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
-
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     actions.print();
 
@@ -221,9 +215,6 @@ TEST(ascent_runtime, test_python_script_extract_import)
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
 
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
     actions.print();
 
     //
@@ -260,7 +251,6 @@ std::string py_script_inception = "\n"
 "add_act =actions.append()\n"
 "add_act['action'] = 'add_scenes'\n"
 "add_act['scenes'] = scenes\n"
-"actions.append()['action'] = 'execute'\n"
 "a.execute(actions)\n"
 "a.close()\n"
 "\n";
@@ -292,9 +282,6 @@ TEST(ascent_runtime, test_python_extract_inception)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
-
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     actions.print();
 

--- a/src/tests/ascent/t_ascent_queries.cpp
+++ b/src/tests/ascent/t_ascent_queries.cpp
@@ -106,8 +106,6 @@ TEST(ascent_queries, max_query)
     conduit::Node &add_queries = actions.append();
     add_queries["action"] = "add_queries";
     add_queries["queries"] = queries;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //
@@ -172,8 +170,6 @@ TEST(ascent_queries, cycle_query)
     conduit::Node &add_queries = actions.append();
     add_queries["action"] = "add_queries";
     add_queries["queries"] = queries;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //

--- a/src/tests/ascent/t_ascent_render_2d.cpp
+++ b/src/tests/ascent/t_ascent_render_2d.cpp
@@ -110,8 +110,6 @@ TEST(ascent_render_2d, test_render_2d_default_runtime)
     conduit::Node &add_scenes = actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -175,8 +173,6 @@ TEST(ascent_render_2d, test_render_2d_uniform_default_runtime)
     conduit::Node &add_scenes = actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -241,8 +237,6 @@ TEST(ascent_render_2d, test_render_2d_render_serial_backend)
     conduit::Node &add_scenes = actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -308,8 +302,6 @@ TEST(ascent_render_2d, test_render_2d_uniform_render_serial_backend)
     conduit::Node &add_scenes = actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_render_3d.cpp
+++ b/src/tests/ascent/t_ascent_render_3d.cpp
@@ -122,8 +122,6 @@ TEST(ascent_render_3d, test_render_3d_render_default_runtime)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -195,8 +193,6 @@ TEST(ascent_render_3d, test_render_3d_points)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -269,8 +265,6 @@ TEST(ascent_render_3d, test_render_3d_points_const_radius)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -345,8 +339,6 @@ TEST(ascent_render_3d, test_render_3d_points_variable_radius)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -421,8 +413,6 @@ TEST(ascent_render_3d, test_render_3d_bg_fg_color)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -494,8 +484,6 @@ TEST(ascent_render_3d, test_render_3d_no_annotations)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -566,8 +554,6 @@ TEST(ascent_render_3d, test_render_3d_name_format)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -639,8 +625,6 @@ TEST(ascent_render_3d, test_render_3d_no_bg)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -713,8 +697,6 @@ TEST(ascent_render_3d, test_render_3d_render_azimuth)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -821,9 +803,6 @@ TEST(ascent_render_3d, test_render_3d_multi_render_default_runtime)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -894,9 +873,6 @@ TEST(ascent_render_3d, test_render_3d_render_mesh)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -987,9 +963,6 @@ TEST(ascent_render_3d, test_render_3d_multi_render_mesh)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -1057,8 +1030,6 @@ TEST(ascent_render_3d, test_render_3d_render_ascent_serial_backend_uniform)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //
@@ -1127,8 +1098,6 @@ TEST(ascent_render_3d, test_render_3d_render_ascent_serial_backend)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -1200,8 +1169,6 @@ TEST(ascent_render_3d, test_render_3d_render_ascent_min_max)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -1273,8 +1240,6 @@ TEST(ascent_render_3d, test_render_3d_render_ascent_openmp_backend)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -1349,8 +1314,6 @@ TEST(ascent_render_3d, test_3d_render_ascent_runtime_cuda_backend)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -1488,8 +1451,6 @@ TEST(ascent_render_3d, test_render_3d_multi_render)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -1568,9 +1529,6 @@ TEST(ascent_render_3d, render_3d_domain_overload)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
 
     //
     // Run Ascent
@@ -1616,8 +1574,6 @@ TEST(ascent_render_3d, render_3d_empty_data)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
 
     //
@@ -1677,8 +1633,6 @@ TEST(ascent_render_3d, test_render_3d_supported_field_dtypes)
     conduit::Node &scenes = add_plots["scenes"];
     scenes["s1/plots/p1/type"]  = "pseudocolor";
     scenes["s1/plots/p1/field"] = "braid";
-    actions.append()["action"]  = "execute";
-    actions.append()["action"]  = "reset";
 
     Ascent ascent;
 
@@ -1940,8 +1894,6 @@ TEST(ascent_render_3d, test_render_3d_supported_conn_dtypes)
     conduit::Node &scenes = add_plots["scenes"];
     scenes["s1/plots/p1/type"]  = "pseudocolor";
     scenes["s1/plots/p1/field"] = "braid";
-    actions.append()["action"] = "execute";
-    actions.append()["action"] = "reset";
 
     Ascent ascent;
 

--- a/src/tests/ascent/t_ascent_rover.cpp
+++ b/src/tests/ascent/t_ascent_rover.cpp
@@ -123,9 +123,6 @@ TEST(ascent_rover, test_xray_serial)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -196,9 +193,6 @@ TEST(ascent_rover, test_volume_min_max)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -266,9 +260,6 @@ TEST(ascent_rover, test_volume_serial)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     add_extracts["extracts"] = extracts;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_runtime_options.cpp
+++ b/src/tests/ascent/t_ascent_runtime_options.cpp
@@ -265,9 +265,6 @@ TEST(ascent_runtime_options, test_actions_file)
                               "          }\n"
                               "        }\n"
                               "      }\n"
-                              "    },\n"
-                              "    {\n"
-                              "      \"action\": \"execute\"\n"
                               "    }\n"
                               "  ]\n";
 
@@ -345,12 +342,12 @@ TEST(ascent_runtime_options, test_actions_yaml_file)
                               "  action: add_scenes\n"
                               "  scenes:\n"
                               "        s1:\n"
-                              "          plots:\n" 
+                              "          plots:\n"
                               "            p1: \n"
                               "              type: pseudocolor\n"
                               "              field: braid\n"
-                              "          renders:\n" 
-                              "            r1:\n" 
+                              "          renders:\n"
+                              "            r1:\n"
                               "              image_name: " + output_file + "\n"
                               "-\n"
                               "  action: execute\n";

--- a/src/tests/ascent/t_ascent_slice.cpp
+++ b/src/tests/ascent/t_ascent_slice.cpp
@@ -140,9 +140,6 @@ TEST(ascent_slice, test_slice)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -228,9 +225,6 @@ TEST(ascent_slice, test_slice_off_axis)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -314,9 +308,6 @@ TEST(ascent_slice, test_3slice)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_threshold.cpp
+++ b/src/tests/ascent/t_ascent_threshold.cpp
@@ -136,9 +136,6 @@ TEST(ascent_threshold, test_threshold_3d)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_triggers.cpp
+++ b/src/tests/ascent/t_ascent_triggers.cpp
@@ -99,8 +99,6 @@ TEST(ascent_triggers, simple_rick)
     // Create trigger actions.
     //
     Node trigger_actions;
-    conduit::Node &trigger_execute = trigger_actions.append();
-    trigger_execute["action"] = "execute";
     trigger_actions.save(trigger_file, "json");
 
     //
@@ -116,8 +114,6 @@ TEST(ascent_triggers, simple_rick)
     conduit::Node &add_triggers= actions.append();
     add_triggers["action"] = "add_triggers";
     add_triggers["triggers"] = triggers;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //
@@ -193,8 +189,6 @@ TEST(ascent_triggers, complex_trigger)
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
 
-    conduit::Node &trigger_execute = trigger_actions.append();
-    trigger_execute["action"] = "execute";
     trigger_actions.save(trigger_file, "json");
 
     //
@@ -210,8 +204,6 @@ TEST(ascent_triggers, complex_trigger)
     conduit::Node &add_triggers= actions.append();
     add_triggers["action"] = "add_triggers";
     add_triggers["triggers"] = triggers;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //
@@ -266,13 +258,13 @@ TEST(ascent_triggers, trigger_extract)
     string trigger_file = conduit::utils::join_file_path(output_path,"trigger_extract_actions");
     string output_file = conduit::utils::join_file_path(output_path,"tout_trigger_extract");
     string output_root_file = output_file + ".cycle_000100.root";
-    
+
     // remove old files
     if(conduit::utils::is_file(trigger_file))
     {
       conduit::utils::remove_file(trigger_file);
     }
-    
+
     if(conduit::utils::is_file(output_root_file))
     {
       conduit::utils::remove_file(output_root_file);
@@ -284,7 +276,7 @@ TEST(ascent_triggers, trigger_extract)
     Node trigger_actions;
 
     conduit::Node extracts;
-    
+
     extracts["e1/type"]  = "relay";
     extracts["e1/params/path"] = output_file;
     extracts["e1/params/protocol"] = "blueprint/mesh/hdf5";
@@ -293,8 +285,6 @@ TEST(ascent_triggers, trigger_extract)
     add_ext["action"] = "add_extracts";
     add_ext["extracts"] = extracts;
 
-    conduit::Node &trigger_execute = trigger_actions.append();
-    trigger_execute["action"] = "execute";
     trigger_actions.save(trigger_file, "json");
 
     //
@@ -310,8 +300,6 @@ TEST(ascent_triggers, trigger_extract)
     conduit::Node &add_triggers= actions.append();
     add_triggers["action"] = "add_triggers";
     add_triggers["triggers"] = triggers;
-    conduit::Node &execute = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     //

--- a/src/tests/ascent/t_ascent_vector_magnitude.cpp
+++ b/src/tests/ascent/t_ascent_vector_magnitude.cpp
@@ -133,9 +133,6 @@ TEST(ascent_vector_mag, test_vector_mag)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent
@@ -216,9 +213,6 @@ TEST(ascent_vector_mag, test_vector_mag_interleaved)
     conduit::Node &add_scenes= actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
-    // execute
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
 
     //
     // Run Ascent

--- a/src/tests/ascent/t_ascent_vtkh_data_adapter.cpp
+++ b/src/tests/ascent/t_ascent_vtkh_data_adapter.cpp
@@ -234,7 +234,7 @@ TEST(ascent_data_adapter, consistent_domain_ids_check)
 TEST(ascent_data_adapter, interleaved_3d)
 {
     // CYRUSH: I tried recreate an issue with interleaved coords
-    // we hit in AMReX with this test case, however it does not 
+    // we hit in AMReX with this test case, however it does not
     // replicate it  (rendering still works with the vtk-m interleaved logic)
     // It is still a good basic interleaved test case.
     Node n;
@@ -278,9 +278,6 @@ TEST(ascent_data_adapter, interleaved_3d)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
-
 
     // make sure we can render interleaved data
     Ascent ascent;

--- a/src/tests/ascent/t_ascent_web_flow.cpp
+++ b/src/tests/ascent/t_ascent_web_flow.cpp
@@ -144,7 +144,6 @@ TEST(ascent_web, test_ascent_web_launch)
     actions[1]["dest"] = "fi";
     actions[1]["port"] = "in";
 
-    actions.append()["action"] = "execute";
     actions.print();
 
     // we want the "flow" runtime
@@ -173,7 +172,6 @@ TEST(ascent_web, test_ascent_web_launch)
         ASCENT_INFO(data["state"].to_json());
         // publish the same mesh data, but update the state info
         actions.reset();
-        actions.append()["action"] = "execute";
         ASCENT_INFO(actions.to_json());
         ascent.publish(data);
         ascent.execute(actions);

--- a/src/tests/ascent/t_ascent_web_main.cpp
+++ b/src/tests/ascent/t_ascent_web_main.cpp
@@ -115,8 +115,6 @@ TEST(ascent_web, test_ascent_main_web_launch)
     conduit::Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
     add_plots["scenes"] = scenes;
-    conduit::Node &execute  = actions.append();
-    execute["action"] = "execute";
     actions.print();
 
     // we want the "flow" runtime
@@ -145,7 +143,6 @@ TEST(ascent_web, test_ascent_main_web_launch)
         ASCENT_INFO(data["state"].to_json());
         // publish the same mesh data, but update the state info
         actions.reset();
-        actions.append()["action"] = "execute";
         ascent.publish(data);
         ascent.execute(actions);
         conduit::utils::sleep(1000);


### PR DESCRIPTION
Implicitly perform `execute` and `reset` and only rebuild graph if actions change.