### PR TITLE
Add ENABLE_SERIAL option, on by default.

### DIFF
--- a/scripts/uberenv/packages/ascent/package.py
+++ b/scripts/uberenv/packages/ascent/package.py
@@ -51,6 +51,7 @@ class Ascent(Package, CudaPackage):
     variant('test', default=True, description='Enable Ascent unit tests')
 
     variant("mpi", default=True, description="Build Ascent MPI Support")
+    variant("serial", default=True, description="build serial (non-mpi) libraries")
 
     # variants for language support
     variant("python", default=True, description="Build Ascent Python support")
@@ -353,6 +354,16 @@ class Ascent(Package, CudaPackage):
             cfg.write(cmake_cache_entry("SPHINX_EXECUTABLE", sphinx_build_exe))
         else:
             cfg.write(cmake_cache_entry("ENABLE_DOCS", "OFF"))
+
+        #######################
+        # Serial
+        #######################
+
+        if "+serial" in spec:
+            cfg.write(cmake_cache_entry("ENABLE_SERIAL", "ON"))
+        else:
+            cfg.write(cmake_cache_entry("ENABLE_SERIAL", "OFF"))
+
 
         #######################
         # MPI

--- a/scripts/uberenv/packages/vtkh/package.py
+++ b/scripts/uberenv/packages/vtkh/package.py
@@ -44,6 +44,7 @@ class Vtkh(Package,CudaPackage):
 
     variant("shared", default=True, description="Build vtk-h as shared libs")
     variant("mpi", default=True, description="build mpi support")
+    variant("serial", default=True, description="build serial (non-mpi) libraries")
     variant("tbb", default=False, description="build tbb support")
     variant("cuda", default=False, description="build cuda support")
     variant("openmp", default=(sys.platform != 'darwin'),
@@ -236,6 +237,15 @@ class Vtkh(Package,CudaPackage):
         #######################################################################
         # Optional Dependencies
         #######################################################################
+
+        #######################
+        # Serial
+        #######################
+
+        if "+serial" in spec:
+            cfg.write(cmake_cache_entry("ENABLE_SERIAL", "ON"))
+        else:
+            cfg.write(cmake_cache_entry("ENABLE_SERIAL", "OFF"))
 
         #######################
         # MPI

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,11 +65,17 @@ option(ENABLE_FORTRAN     "Build Fortran support"     ON)
 option(ENABLE_PYTHON      "Build Python Support"      ON)
 
 option(ENABLE_MPI         "Build MPI Support"         ON)
+option(ENABLE_SERIAL      "Build Serial (non-MPI) Support" ON)
 option(ENABLE_CUDA        "Build CUDA Support"        OFF)
 option(ENABLE_OPENMP      "Build OpenMP Support"      OFF)
 
 option(ENABLE_EXAMPLES    "Build Examples"            ON)
 option(ENABLE_UTILS       "Build Utilities"           ON)
+
+if(NOT ENABLE_SERIAL AND NOT ENABLE_MPI)
+  message(FATAL_ERROR "No libraries are built. "
+    "Please set ENABLE_SERIAL, ENABLE_MPI or both to ON")
+endif()
 
 
 if(ENABLE_CUDA)

--- a/src/ascent/CMakeLists.txt
+++ b/src/ascent/CMakeLists.txt
@@ -238,27 +238,27 @@ endif()
 ##########################################
 # Build a serial version of ascent
 ##########################################
-
-blt_add_library(
-    NAME        ascent
-    SOURCES     ${ascent_sources}
-    HEADERS     ${ascent_headers}
-    DEPENDS_ON  ${ascent_thirdparty_libs})
-
-if(VTKM_FOUND)
-    set(ascent_device_sources ${ascent_vtkh_dep_sources})
-    list(APPEND ascent_device_sources runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp)
-
-    vtkm_add_target_information(ascent DEVICE_SOURCES ${ascent_device_sources})
+if (ENABLE_SERIAL)
+    blt_add_library(
+        NAME        ascent
+        SOURCES     ${ascent_sources}
+        HEADERS     ${ascent_headers}
+        DEPENDS_ON  ${ascent_thirdparty_libs})
+    
+    if(VTKM_FOUND)
+        set(ascent_device_sources ${ascent_vtkh_dep_sources})
+        list(APPEND ascent_device_sources runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp)
+    
+        vtkm_add_target_information(ascent DEVICE_SOURCES ${ascent_device_sources})
+    endif()
+    # install target for serial ascent lib
+    install(TARGETS ascent
+            EXPORT  ascent
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION lib
+    )
 endif()
-# install target for serial ascent lib
-install(TARGETS ascent
-        EXPORT  ascent
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION lib
-)
-
 
 ################################################
 # Build Parallel (MPI) version of ascent

--- a/src/ascent/python/ascent_module/CMakeLists.txt
+++ b/src/ascent/python/ascent_module/CMakeLists.txt
@@ -46,8 +46,6 @@ if (ENABLE_SERIAL)
     # Specify the sources of the pure python and compiled portions of our module.
     SET(ascent_py_python_sources  py_src/__init__.py 
                                   py_src/ascent.py
-                                  py_src/mpi/__init__.py
-                                  py_src/mpi/ascent_mpi.py
                                   py_src/bridge_kernel/__init__.py
                                   py_src/bridge_kernel/mpi_server.py
                                   py_src/bridge_kernel/server.py

--- a/src/ascent/python/ascent_module/CMakeLists.txt
+++ b/src/ascent/python/ascent_module/CMakeLists.txt
@@ -42,31 +42,32 @@
 #
 ###############################################################################
 
-# Specify the sources of the pure python and compiled portions of our module.
-SET(ascent_py_python_sources  py_src/__init__.py 
-                              py_src/ascent.py
-                              py_src/mpi/__init__.py
-                              py_src/mpi/ascent_mpi.py
-                              py_src/bridge_kernel/__init__.py
-                              py_src/bridge_kernel/mpi_server.py
-                              py_src/bridge_kernel/server.py
-                              py_src/bridge_kernel/utils.py
-                              )
-
-SET(ascent_py_cpp_sources     ascent_python.cpp)
-
-
-# Setup our module
-PYTHON_ADD_HYBRID_MODULE(ascent_python
-                         python-modules
-                         ascent
-                         setup.py
-                         "${ascent_py_python_sources}"
-                         ${ascent_py_cpp_sources})
-
-# link with the proper libs (beyond python)
-target_link_libraries(ascent_python ascent)
-
+if (ENABLE_SERIAL)
+    # Specify the sources of the pure python and compiled portions of our module.
+    SET(ascent_py_python_sources  py_src/__init__.py 
+                                  py_src/ascent.py
+                                  py_src/mpi/__init__.py
+                                  py_src/mpi/ascent_mpi.py
+                                  py_src/bridge_kernel/__init__.py
+                                  py_src/bridge_kernel/mpi_server.py
+                                  py_src/bridge_kernel/server.py
+                                  py_src/bridge_kernel/utils.py
+                                  )
+    
+    SET(ascent_py_cpp_sources     ascent_python.cpp)
+    
+    
+    # Setup our module
+    PYTHON_ADD_HYBRID_MODULE(ascent_python
+                             python-modules
+                             ascent
+                             setup.py
+                             "${ascent_py_python_sources}"
+                             ${ascent_py_cpp_sources})
+    
+    # link with the proper libs (beyond python)
+    target_link_libraries(ascent_python ascent)
+endif()
 
 if(MPI_FOUND)
     # Specify the sources of the pure python and compiled portions of our module.

--- a/src/ascent/python/ascent_module/py_src/ascent.py
+++ b/src/ascent/python/ascent_module/py_src/ascent.py
@@ -55,9 +55,12 @@
 
 
 def about():
-    from .ascent_python import about as ascent_about
-    return ascent_about()
-
+    try:
+        from .ascent_python import about as ascent_about
+        return ascent_about()
+    except ImportError:
+        raise ImportError('failed to import ascent_python, did you ENABLE_SERIAL?')
+    return None
 
 def Ascent():
     from .ascent_python import Ascent as ascent_obj

--- a/src/config/ascent_setup_targets.cmake
+++ b/src/config/ascent_setup_targets.cmake
@@ -55,44 +55,44 @@ else()
     set(ASCENT_FORTRAN_ENABLED FALSE)
 endif()
 
-# create convenience target that bundles all reg ascent deps (ascent::ascent)
-
-add_library(ascent::ascent INTERFACE IMPORTED)
-
-set_property(TARGET ascent::ascent
-             APPEND PROPERTY
-             INTERFACE_INCLUDE_DIRECTORIES "${ASCENT_INSTALL_PREFIX}/include/")
-
-set_property(TARGET ascent::ascent
-             APPEND PROPERTY
-             INTERFACE_INCLUDE_DIRECTORIES "${ASCENT_INSTALL_PREFIX}/include/ascent/")
-
-set_property(TARGET ascent::ascent
-             PROPERTY INTERFACE_LINK_LIBRARIES
-             ascent)
-
-# try to include conduit with new exports
-if(TARGET conduit::conduit)
-    set_property(TARGET ascent::ascent
-                 APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                 conduit::conduit)
-else()
-    # if not, bottle conduit
+if (ENABLE_SERIAL)
+    # create convenience target that bundles all reg ascent deps (ascent::ascent)
+    add_library(ascent::ascent INTERFACE IMPORTED)
+    
     set_property(TARGET ascent::ascent
                  APPEND PROPERTY
-                 INTERFACE_INCLUDE_DIRECTORIES ${CONDUIT_INCLUDE_DIRS})
-
+                 INTERFACE_INCLUDE_DIRECTORIES "${ASCENT_INSTALL_PREFIX}/include/")
+    
     set_property(TARGET ascent::ascent
-                 APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                 conduit conduit_relay conduit_blueprint)
-endif()
-
-if(VTKH_FOUND)
+                 APPEND PROPERTY
+                 INTERFACE_INCLUDE_DIRECTORIES "${ASCENT_INSTALL_PREFIX}/include/ascent/")
+    
     set_property(TARGET ascent::ascent
-                 APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                 vtkh)
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                 ascent)
+    
+    # try to include conduit with new exports
+    if(TARGET conduit::conduit)
+        set_property(TARGET ascent::ascent
+                     APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+                     conduit::conduit)
+    else()
+        # if not, bottle conduit
+        set_property(TARGET ascent::ascent
+                     APPEND PROPERTY
+                     INTERFACE_INCLUDE_DIRECTORIES ${CONDUIT_INCLUDE_DIRS})
+    
+        set_property(TARGET ascent::ascent
+                     APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+                     conduit conduit_relay conduit_blueprint)
+    endif()
+    
+    if(VTKH_FOUND)
+        set_property(TARGET ascent::ascent
+                     APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+                     vtkh)
+    endif()
 endif()
-
 
 # and if mpi enabled, a convenience target mpi case (ascent::cascent_mpi)
 if(ASCENT_MPI_ENABLED)

--- a/src/examples/proxies/laghos/CMakeLists.txt
+++ b/src/examples/proxies/laghos/CMakeLists.txt
@@ -34,21 +34,23 @@ if(MPI_FOUND AND ENABLE_MPI)
   list(APPEND laghos_thirdparty_deps mpi)
 endif()
 
-blt_add_executable(
-    NAME        laghos_ser
-    HEADERS     ${laghos_headers}
-    SOURCES     ${laghos_sources}
-    DEPENDS_ON  ${laghos_thirdparty_deps} ascent
-    OUTPUT_DIR  ${CMAKE_CURRENT_BINARY_DIR})
-
-
-# install target for laghos serial
-install(TARGETS laghos_ser
-        EXPORT  ascent
-        LIBRARY DESTINATION examples/ascent/proxies/laghos
-        ARCHIVE DESTINATION examples/ascent/proxies/laghos
-        RUNTIME DESTINATION examples/ascent/proxies/laghos
-)
+if (ENABLE_SERIAL)
+    blt_add_executable(
+        NAME        laghos_ser
+        HEADERS     ${laghos_headers}
+        SOURCES     ${laghos_sources}
+        DEPENDS_ON  ${laghos_thirdparty_deps} ascent
+        OUTPUT_DIR  ${CMAKE_CURRENT_BINARY_DIR})
+    
+    
+    # install target for laghos serial
+    install(TARGETS laghos_ser
+            EXPORT  ascent
+            LIBRARY DESTINATION examples/ascent/proxies/laghos
+            ARCHIVE DESTINATION examples/ascent/proxies/laghos
+            RUNTIME DESTINATION examples/ascent/proxies/laghos
+    )
+endif()
 
 if(MPI_FOUND AND ENABLE_MPI)
 

--- a/src/examples/proxies/lulesh2.0.3/CMakeLists.txt
+++ b/src/examples/proxies/lulesh2.0.3/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
    set(lulesh_openmp_flags "")
 endif()
 
-if (ENABLE_SER)
+if (ENABLE_SERIAL)
     blt_add_executable(
         NAME        lulesh_ser
         SOURCES     ${LULESH_SOURCES}

--- a/src/examples/proxies/lulesh2.0.3/CMakeLists.txt
+++ b/src/examples/proxies/lulesh2.0.3/CMakeLists.txt
@@ -67,22 +67,24 @@ else()
    set(lulesh_openmp_flags "")
 endif()
 
-blt_add_executable(
-    NAME        lulesh_ser
-    SOURCES     ${LULESH_SOURCES}
-    DEPENDS_ON  ${lulesh_deps}
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
-
-blt_add_target_compile_flags(TO lulesh_ser FLAGS "-DUSE_MPI=0 ${lulesh_openmp_flags}")
-
-# install target for lulesh serial
-install(TARGETS lulesh_ser
-        EXPORT  ascent
-        LIBRARY DESTINATION examples/ascent/proxies/lulesh
-        ARCHIVE DESTINATION examples/ascent/proxies/lulesh
-        RUNTIME DESTINATION examples/ascent/proxies/lulesh
-)
+if (ENABLE_SER)
+    blt_add_executable(
+        NAME        lulesh_ser
+        SOURCES     ${LULESH_SOURCES}
+        DEPENDS_ON  ${lulesh_deps}
+        OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    
+    
+    blt_add_target_compile_flags(TO lulesh_ser FLAGS "-DUSE_MPI=0 ${lulesh_openmp_flags}")
+    
+    # install target for lulesh serial
+    install(TARGETS lulesh_ser
+            EXPORT  ascent
+            LIBRARY DESTINATION examples/ascent/proxies/lulesh
+            ARCHIVE DESTINATION examples/ascent/proxies/lulesh
+            RUNTIME DESTINATION examples/ascent/proxies/lulesh
+    )
+endif()
 
 install(FILES ASCENT_README.md
               ascent_actions.json

--- a/src/examples/synthetic/noise/CMakeLists.txt
+++ b/src/examples/synthetic/noise/CMakeLists.txt
@@ -63,21 +63,23 @@ else()
    set(noise_openmp_flags "")
 endif()
 
-blt_add_executable(
-    NAME        noise_ser
-    SOURCES     ${noise_sources}
-    DEPENDS_ON  ${noise_deps}
-    OUTPUT_DIR  ${CMAKE_CURRENT_BINARY_DIR})
-
-blt_add_target_compile_flags(TO noise_ser FLAGS "${noise_openmp_flags}")
-
-# install target for noise example
-install(TARGETS noise_ser
-        EXPORT  ascent
-        LIBRARY DESTINATION examples/ascent/synthetic/noise
-        ARCHIVE DESTINATION examples/ascent/synthetic/noise
-        RUNTIME DESTINATION examples/ascent/synthetic/noise
-)
+if (ENABLE_SERIAL)
+    blt_add_executable(
+        NAME        noise_ser
+        SOURCES     ${noise_sources}
+        DEPENDS_ON  ${noise_deps}
+        OUTPUT_DIR  ${CMAKE_CURRENT_BINARY_DIR})
+    
+    blt_add_target_compile_flags(TO noise_ser FLAGS "${noise_openmp_flags}")
+    
+    # install target for noise example
+    install(TARGETS noise_ser
+            EXPORT  ascent
+            LIBRARY DESTINATION examples/ascent/synthetic/noise
+            ARCHIVE DESTINATION examples/ascent/synthetic/noise
+            RUNTIME DESTINATION examples/ascent/synthetic/noise
+    )
+endif()
 
 install(FILES ASCENT_README.md DESTINATION examples/ascent/synthetic/noise)
 

--- a/src/tests/ascent/CMakeLists.txt
+++ b/src/tests/ascent/CMakeLists.txt
@@ -111,21 +111,22 @@ endif()
 ################################
 # Add main tests
 ################################
-message(STATUS "Adding ascent lib unit tests")
-foreach(TEST ${BASIC_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON ascent)
-endforeach()
-
-foreach(TEST ${VTKH_DEP_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON ascent)
-endforeach()
-
-if(VTKM_FOUND)
-  # special test case where we test vtkm conversions
-   vtkm_add_target_information(t_ascent_vtkh_data_adapter
-                               DEVICE_SOURCES t_ascent_vtkh_data_adapter.cpp)
+if (ENABLE_SERIAL)
+    message(STATUS "Adding ascent lib unit tests")
+    foreach(TEST ${BASIC_TESTS})
+        add_cpp_test(TEST ${TEST} DEPENDS_ON ascent)
+    endforeach()
+    
+    foreach(TEST ${VTKH_DEP_TESTS})
+        add_cpp_test(TEST ${TEST} DEPENDS_ON ascent)
+    endforeach()
+    
+    if(VTKM_FOUND)
+      # special test case where we test vtkm conversions
+       vtkm_add_target_information(t_ascent_vtkh_data_adapter
+                                   DEVICE_SOURCES t_ascent_vtkh_data_adapter.cpp)
+    endif()
 endif()
-
 ################################
 # Add optional tests
 ################################

--- a/src/tests/ascent/fortran/CMakeLists.txt
+++ b/src/tests/ascent/fortran/CMakeLists.txt
@@ -46,21 +46,21 @@
 ###############################################################################
 # Ascent Fortran Interface Unit Tests
 ###############################################################################
-
-set(FORTRAN_TESTS
-    t_f_ascent_smoke
-    t_f_ascent_render_2d)
-
-
-################################
-# Add our tests
-################################
-message(STATUS "Adding ascent lib fortran interface unit tests")
-foreach(TEST ${FORTRAN_TESTS})
-    add_fortran_test(TEST ${TEST} DEPENDS_ON ascent
-                                             conduit_blueprint)
-endforeach()
-
+if (ENABLE_SERIAL)
+    set(FORTRAN_TESTS
+        t_f_ascent_smoke
+        t_f_ascent_render_2d)
+    
+    
+    ################################
+    # Add our tests
+    ################################
+    message(STATUS "Adding ascent lib fortran interface unit tests")
+    foreach(TEST ${FORTRAN_TESTS})
+        add_fortran_test(TEST ${TEST} DEPENDS_ON ascent
+                                                 conduit_blueprint)
+    endforeach()
+endif()
 
 
 

--- a/src/tests/flow/CMakeLists.txt
+++ b/src/tests/flow/CMakeLists.txt
@@ -50,32 +50,30 @@
 ################################
 # Flow Unit Tests
 ################################
-if (ENABLE_SERIAL)
-    set(FLOW_TESTS  t_flow_data
-                    t_flow_timer
-                    t_flow_registry
-                    t_flow_workspace
-                    t_flow_workspace_adv_manage)
-    
-    if(PYTHON_FOUND)
-        list(APPEND FLOW_TESTS t_flow_python_interpreter
-                               t_flow_python_script_filter)
-    endif()
-    
-    ################################
-    # Add tests
-    ################################
-    
-    #(tests depend on ascent b/c we are using some of its utils in the tests)
-    
-    message(STATUS "Adding flow lib unit tests")
-    foreach(TEST ${FLOW_TESTS})
-        add_cpp_test(TEST ${TEST} DEPENDS_ON ascent_flow ascent)
-    endforeach()
-    
-    if(PYTHON_FOUND AND ENABLE_PYTHON)
-        add_subdirectory("python")
-    else()
-        message(STATUS "Python disabled: Skipping ascent python module tests")
-    endif()
+set(FLOW_TESTS  t_flow_data
+                t_flow_timer
+                t_flow_registry
+                t_flow_workspace
+                t_flow_workspace_adv_manage)
+
+if(PYTHON_FOUND)
+    list(APPEND FLOW_TESTS t_flow_python_interpreter
+                           t_flow_python_script_filter)
+endif()
+
+################################
+# Add tests
+################################
+
+#(tests depend on ascent b/c we are using some of its utils in the tests)
+
+message(STATUS "Adding flow lib unit tests")
+foreach(TEST ${FLOW_TESTS})
+    add_cpp_test(TEST ${TEST} DEPENDS_ON ascent_flow)
+endforeach()
+
+if(PYTHON_FOUND AND ENABLE_PYTHON)
+    add_subdirectory("python")
+else()
+    message(STATUS "Python disabled: Skipping ascent python module tests")
 endif()

--- a/src/tests/flow/CMakeLists.txt
+++ b/src/tests/flow/CMakeLists.txt
@@ -50,31 +50,32 @@
 ################################
 # Flow Unit Tests
 ################################
-
-set(FLOW_TESTS  t_flow_data
-                t_flow_timer
-                t_flow_registry
-                t_flow_workspace
-                t_flow_workspace_adv_manage)
-
-if(PYTHON_FOUND)
-    list(APPEND FLOW_TESTS t_flow_python_interpreter
-                           t_flow_python_script_filter)
-endif()
-
-################################
-# Add tests
-################################
-
-#(tests depend on ascent b/c we are using some of its utils in the tests)
-
-message(STATUS "Adding flow lib unit tests")
-foreach(TEST ${FLOW_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON ascent_flow ascent)
-endforeach()
-
-if(PYTHON_FOUND AND ENABLE_PYTHON)
-    add_subdirectory("python")
-else()
-    message(STATUS "Python disabled: Skipping ascent python module tests")
+if (ENABLE_SERIAL)
+    set(FLOW_TESTS  t_flow_data
+                    t_flow_timer
+                    t_flow_registry
+                    t_flow_workspace
+                    t_flow_workspace_adv_manage)
+    
+    if(PYTHON_FOUND)
+        list(APPEND FLOW_TESTS t_flow_python_interpreter
+                               t_flow_python_script_filter)
+    endif()
+    
+    ################################
+    # Add tests
+    ################################
+    
+    #(tests depend on ascent b/c we are using some of its utils in the tests)
+    
+    message(STATUS "Adding flow lib unit tests")
+    foreach(TEST ${FLOW_TESTS})
+        add_cpp_test(TEST ${TEST} DEPENDS_ON ascent_flow ascent)
+    endforeach()
+    
+    if(PYTHON_FOUND AND ENABLE_PYTHON)
+        add_subdirectory("python")
+    else()
+        message(STATUS "Python disabled: Skipping ascent python module tests")
+    endif()
 endif()

--- a/src/tests/t_utils.hpp
+++ b/src/tests/t_utils.hpp
@@ -64,7 +64,7 @@ using namespace std;
 using namespace conduit;
 
 //-----------------------------------------------------------------------------
-void
+inline void
 remove_test_image(const std::string &path, const std::string num = "100")
 {
     if(conduit::utils::is_file(path + num + ".png"))
@@ -80,7 +80,7 @@ remove_test_image(const std::string &path, const std::string num = "100")
 }
 
 //-----------------------------------------------------------------------------
-void
+inline void
 remove_test_file(const std::string &path)
 {
     if(conduit::utils::is_file(path))
@@ -90,7 +90,7 @@ remove_test_file(const std::string &path)
 }
 
 //-----------------------------------------------------------------------------
-std::string
+inline std::string
 prepare_output_dir()
 {
     string output_path = ASCENT_T_BIN_DIR;
@@ -106,14 +106,14 @@ prepare_output_dir()
 }
 
 //----------------------------------------------------------------------------
-std::string
+inline std::string
 output_dir()
 {
     return conduit::utils::join_file_path(ASCENT_T_BIN_DIR,"_output");;
 }
 
 //-----------------------------------------------------------------------------
-bool
+inline bool
 check_test_image(const std::string &path, const float tolerance = 0.001f, std::string num = "100")
 {
     Node info;
@@ -164,7 +164,7 @@ check_test_image(const std::string &path, const float tolerance = 0.001f, std::s
     return res;
 }
 
-bool
+inline bool
 check_test_file(const std::string &path)
 {
     // for now, just check if the file exists.
@@ -175,7 +175,7 @@ check_test_file(const std::string &path)
 //-----------------------------------------------------------------------------
 // create an example 2d rectilinear grid with two variables.
 //-----------------------------------------------------------------------------
-void
+inline void
 create_2d_example_dataset(Node &data,
                           int par_rank=0,
                           int par_size=1)
@@ -278,7 +278,7 @@ create_2d_example_dataset(Node &data,
 //-----------------------------------------------------------------------------
 // create an example 3d rectilinear grid with two variables.
 //-----------------------------------------------------------------------------
-void
+inline void
 create_3d_example_dataset(Node &data,
                           int cell_dim,
                           int par_rank,
@@ -394,7 +394,8 @@ create_3d_example_dataset(Node &data,
     }
 }
 
-void add_interleaved_vector(conduit::Node &dset)
+inline void
+add_interleaved_vector(conduit::Node &dset)
 {
   int dims = dset["fields/vel/values"].number_of_children();
   if(dims != 2 && dims != 3)

--- a/src/utilities/replay/CMakeLists.txt
+++ b/src/utilities/replay/CMakeLists.txt
@@ -57,19 +57,21 @@ if(OPENMP_FOUND)
    list(APPEND deps openmp)
 endif()
 
-blt_add_executable(
-    NAME        replay_ser
-    SOURCES     ${REPLAY_SOURCES}
-    DEPENDS_ON  ${replay_deps}
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
-# install target for replay serial
-install(TARGETS replay_ser
-        EXPORT  ascent
-        LIBRARY DESTINATION utilities/ascent/replay
-        ARCHIVE DESTINATION utilities/ascent/replay
-        RUNTIME DESTINATION utilities/ascent/replay
-)
+if (ENABLE_SERIAL)
+    blt_add_executable(
+        NAME        replay_ser
+        SOURCES     ${REPLAY_SOURCES}
+        DEPENDS_ON  ${replay_deps}
+        OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    
+    # install target for replay serial
+    install(TARGETS replay_ser
+            EXPORT  ascent
+            LIBRARY DESTINATION utilities/ascent/replay
+            ARCHIVE DESTINATION utilities/ascent/replay
+            RUNTIME DESTINATION utilities/ascent/replay
+    )
+endif()
 
 if(MPI_FOUND)
 


### PR DESCRIPTION
This allows users to build only ascent_mpi
(by setting ENABLE_SERIAL) to off) to avoid issues
when building ascent that links with vtkm with MPI enabled.