### PR TITLE
cori auto-build update and cmake exported target fixes

### DIFF
--- a/scripts/uberenv/packages/ascent/package.py
+++ b/scripts/uberenv/packages/ascent/package.py
@@ -372,12 +372,21 @@ class Ascent(Package, CudaPackage):
         cfg.write("# MPI Support\n")
 
         if "+mpi" in spec:
+            mpicc_path = spec['mpi'].mpicc
+            mpicxx_path = spec['mpi'].mpicxx
+            mpifc_path = spec['mpi'].mpifc
+            # if we are using compiler wrappers on cray systems
+            # use those for mpi wrappers, b/c  spec['mpi'].mpicxx 
+            # etc make return the spack compiler wrappers 
+            # which can trip up mpi detection in CMake 3.14
+            if cxx_compiler == "CC":
+                mpicc_path = "cc"
+                mpicxx_path = "CC"
+                mpifc_path = "ftn"
             cfg.write(cmake_cache_entry("ENABLE_MPI", "ON"))
-            cfg.write(cmake_cache_entry("MPI_C_COMPILER", spec['mpi'].mpicc))
-            cfg.write(cmake_cache_entry("MPI_CXX_COMPILER",
-                                        spec['mpi'].mpicxx))
-            cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER",
-                                        spec['mpi'].mpifc))
+            cfg.write(cmake_cache_entry("MPI_C_COMPILER", mpicc_path ))
+            cfg.write(cmake_cache_entry("MPI_CXX_COMPILER", mpicxx_path ))
+            cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER", mpifc_path ))
             mpiexe_bin = join_path(spec['mpi'].prefix.bin, 'mpiexec')
             if os.path.isfile(mpiexe_bin):
                 # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE

--- a/scripts/uberenv/packages/ascent/package.py
+++ b/scripts/uberenv/packages/ascent/package.py
@@ -379,7 +379,7 @@ class Ascent(Package, CudaPackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx 
             # etc make return the spack compiler wrappers 
             # which can trip up mpi detection in CMake 3.14
-            if cxx_compiler == "CC":
+            if cpp_compiler == "CC":
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
                 mpifc_path = "ftn"

--- a/scripts/uberenv/spack_configs/nersc/cori/compilers.yaml
+++ b/scripts/uberenv/spack_configs/nersc/cori/compilers.yaml
@@ -5,41 +5,14 @@ compilers:
     flags: {}
     modules:
     - PrgEnv-gnu
+    - gcc/8.2.0
     operating_system: cnl9
     paths:
       cc: cc
       cxx: CC
       f77: ftn
       fc: ftn
-    spec: gcc@7.3.0
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-gnu
-    operating_system: cnl9
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: gcc@4.9.3
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-gnu
-    operating_system: cnl9
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: gcc@5.3.0
+    spec: gcc@8.2.0
     target: any
 - compiler:
     environment: {}
@@ -47,68 +20,12 @@ compilers:
     flags: {}
     modules:
     - PrgEnv-intel
-    - intel/18.0.1.163
+    - intel/19.0.3.199
     operating_system: cnl9
     paths:
       cc: cc
       cxx: CC
       f77: ftn
       fc: ftn
-    spec: intel@18.0.1.163
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-gnu
-    operating_system: cnl9
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: gcc@6.2.0
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-gnu
-    operating_system: cnl9
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: gcc@5.2.0
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-gnu
-    operating_system: cnl9
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: gcc@6.1.0
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-gnu
-    operating_system: cnl9
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: gcc@6.3.0
+    spec: intel@19.0.3.199 
     target: any

--- a/scripts/uberenv/spack_configs/nersc/cori/packages.yaml
+++ b/scripts/uberenv/spack_configs/nersc/cori/packages.yaml
@@ -24,7 +24,7 @@
 
 packages:
   all:
-    compiler: [gcc@7.3.0, intel@18.0.1.163]
+    compiler: [gcc@8.2.0, intel@19.0.3.199]
     modules: {}
     paths: {}
     providers:
@@ -33,10 +33,10 @@ packages:
       lapack: [openblas]
     variants: +mpi 
   mpich:
-    version: [7.7.0]
+    version: [7.7.6]
     buildable: false
     modules:
-        mpich@7.7.0: cray-mpich
+        mpich@7.7.6: cray-mpich/7.7.6
     paths: {}
     providers: {}
     compiler: []
@@ -48,7 +48,7 @@ packages:
   intel-mkl:
       buildable: False
       paths:
-        intel-mkl%intel@18.0.1.163: /opt/intel
+        intel-mkl%intel@19.0.3.199: /opt/intel
   perl:
       buildable: False
       paths:
@@ -58,7 +58,7 @@ packages:
   cmake:
       buildable: False
       paths:
-       cmake@3.9.6: /project/projectdirs/alpine/software/cmake/3.9.6/
+       cmake: /project/projectdirs/alpine/software/cmake/3.14.6/
   python:
       variants: ~dbm
   pkg-config:

--- a/src/ascent/CMakeLists.txt
+++ b/src/ascent/CMakeLists.txt
@@ -193,7 +193,16 @@ endif()
 if(FORTRAN_FOUND)
     add_library(ascent_fortran OBJECT fortran/ascent_fortran.f90)
     list(APPEND ascent_sources $<TARGET_OBJECTS:ascent_fortran>)
+    
+    #####################################################
+    # Setup install to copy the fortran modules
+    #####################################################
+    install(FILES 
+            ${CMAKE_Fortran_MODULE_DIRECTORY}/ascent.mod
+            DESTINATION include/ascent)
 endif()
+
+
 
 ################################
 # Add python wrappers if python

--- a/src/cmake/thirdparty/SetupConduit.cmake
+++ b/src/cmake/thirdparty/SetupConduit.cmake
@@ -102,7 +102,7 @@ if(PYTHON_FOUND)
                         OUTPUT_VARIABLE _FIND_CONDUIT_PYTHON_OUT
                         ERROR_VARIABLE  _FIND_CONDUIT_PYTHON_ERROR_VALUE
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
-                      message(STATUS "PYTHOn found!! ${CONDUIT_DIR}")
+                      message(STATUS "PYTHON found!! ${CONDUIT_DIR}")
         if(_FIND_CONDUIT_PYTHON_RESULT MATCHES 0)
             message(STATUS "FOUND conduit python module at: ${_FIND_CONDUIT_PYTHON_OUT}")
         else()

--- a/src/config/AscentConfig.cmake.in
+++ b/src/config/AscentConfig.cmake.in
@@ -62,6 +62,9 @@ if(NOT ASCENT_FOUND)
     set(ASCENT_INSTALL_PREFIX "@ASCENT_INSTALL_PREFIX@")
     set(ASCENT_CONDUIT_DIR  "@CONDUIT_DIR@")
 
+    # advertise if fortran support is enabled
+    set(ASCENT_FORTRAN_ENABLED @ENABLE_FORTRAN@)
+
     # advertise if vtk-h support is enabled
     set(ASCENT_VTKH_ENABLED @VTKH_FOUND@)
     set(ASCENT_VTKH_DIR "@VTKH_DIR@")
@@ -71,9 +74,11 @@ if(NOT ASCENT_FOUND)
     set(ASCENT_MFEM_ENABLED @MFEM_FOUND@)
     set(ASCENT_MFEM_DIR "@MFEM_DIR@")
 
-
+    # advertise if python support is enabled
+    set(ASCENT_PYTHON_ENABLED @PYTHON_FOUND@)
     set(ASCENT_PYTHON_EXECUTABLE "@PYTHON_EXECUTABLE@")
     
+    set(ASCENT_SERIAL_ENABLED @ENABLE_SERIAL@)
     set(ASCENT_MPI_ENABLED @ENABLE_MPI@)
 
     # pull in vars with details about configured paths

--- a/src/config/ascent_setup_targets.cmake
+++ b/src/config/ascent_setup_targets.cmake
@@ -48,14 +48,7 @@ set(ASCENT_INCLUDE_DIRS "${ASCENT_INSTALL_PREFIX}/include/ascent")
 # Probe Ascent Features
 #
 
-# check for fortran support
-if(EXISTS ${ASCENT_INSTALL_PREFIX}/include/ascent/ascent.mod)
-    set(ASCENT_FORTRAN_ENABLED TRUE)
-else()
-    set(ASCENT_FORTRAN_ENABLED FALSE)
-endif()
-
-if (ENABLE_SERIAL)
+if(ASCENT_SERIAL_ENABLED)
     # create convenience target that bundles all reg ascent deps (ascent::ascent)
     add_library(ascent::ascent INTERFACE IMPORTED)
     
@@ -87,7 +80,7 @@ if (ENABLE_SERIAL)
                      conduit conduit_relay conduit_blueprint)
     endif()
     
-    if(VTKH_FOUND)
+    if(ASCENT_VTKH_ENABLED)
         set_property(TARGET ascent::ascent
                      APPEND PROPERTY INTERFACE_LINK_LIBRARIES
                      vtkh)
@@ -116,7 +109,7 @@ if(ASCENT_MPI_ENABLED)
                      conduit conduit_relay conduit_relay_mpi conduit_blueprint)
     endif()
     
-    if(VTKH_FOUND)
+    if(ASCENT_VTKH_ENABLED)
         set_property(TARGET ascent::ascent_mpi
                      APPEND PROPERTY INTERFACE_LINK_LIBRARIES
                      vtkh_mpi)
@@ -130,12 +123,21 @@ if(NOT Ascent_FIND_QUIETLY)
     message(STATUS "ASCENT_VERSION             = ${ASCENT_VERSION}")
     message(STATUS "ASCENT_INSTALL_PREFIX      = ${ASCENT_INSTALL_PREFIX}")
     message(STATUS "ASCENT_INCLUDE_DIRS        = ${ASCENT_INCLUDE_DIRS}")
+    message(STATUS "ASCENT_SERIAL_ENABLED      = ${ASCENT_SERIAL_ENABLED}")
+    message(STATUS "ASCENT_MPI_ENABLED         = ${ASCENT_MPI_ENABLED}")
     message(STATUS "ASCENT_FORTRAN_ENABLED     = ${ASCENT_FORTRAN_ENABLED}")
+    message(STATUS "ASCENT_VTKH_ENABLED        = ${ASCENT_VTKH_ENABLED}")
+    message(STATUS "ASCENT_PYTHON_ENABLED      = ${ASCENT_PYTHON_ENABLED}")
     message(STATUS "ASCENT_PYTHON_EXECUTABLE   = ${ASCENT_PYTHON_EXECUTABLE}")
 
-    set(_print_targets "ascent::ascent")
+
+    set(_print_targets "")
+    if(ASCENT_SERIAL_ENABLED)
+        set(_print_targets "ascent::ascent ")
+    endif()
+
     if(ASCENT_MPI_ENABLED)
-        set(_print_targets "${_print_targets} ascent::ascent_mpi")
+        set(_print_targets "${_print_targets}ascent::ascent_mpi")
     endif()
 
     message(STATUS "Ascent imported targets: ${_print_targets}")


### PR DESCRIPTION
* update with latest compilers for nersc cori 
* add missing install of ascent.mod when fortran is on
* fix logic for creating ascent::ascent when ENABLE_SERIAL  == ON