### PR TITLE
fixing cinema bounds/zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 ## Unreleased
 
+### Fixed
+- Issue where cycle was not properly propagated when converting mfem data.
+- Cinema issue where zoom was applied additively each cycle to oblivion.s
+- Cinema issue where cameras were not following the center of the data set
+
 ## [0.5.0] - Released 2019-11-14
 
 ### Added
@@ -26,9 +31,9 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Updated to VTK-m 1.5.0 and associated VTK-h.
 - Imposed necessary static build constraints for cuda support.
 
- 
+
 ### Fixed
-- Several minor bug fixes 
+- Several minor bug fixes
 
 [Unreleased]: https://github.com/Alpine-DAV/ascent/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/Alpine-DAV/ascent/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 ### Fixed
 - Issue where cycle was not properly propagated when converting mfem data.
-- Cinema issue where zoom was applied additively each cycle to oblivion.s
-- Cinema issue where cameras were not following the center of the data set
+- Cinema issue where zoom was applied additively each cycle to oblivion.
+- Cinema issue where cameras were not following the center of the data set.
 
 ## [0.5.0] - Released 2019-11-14
 


### PR DESCRIPTION
This fixes two cinema related issue:
- zoom was additive (just as vtkm intended). Now its not.
- The cameras were only generated once, which did not track if the data set moved or the plot changed. Now, the cameras are updated if the bounds change.