### PR TITLE
fix cinema camera setup to also include positions on the lower hemisp…

### DIFF
--- a/src/ascent/runtimes/flow_filters/ascent_runtime_vtkh_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_vtkh_filters.cpp
@@ -643,11 +643,17 @@ private:
     double theta_inc = 180.0 / double(m_theta);
     for(int p = 0; p < m_phi; ++p)
     {
+      float phi  =  -180.f + phi_inc * p;
+      m_phi_values.push_back(phi);
+
       for(int t = 0; t < m_theta; ++t)
       {
-        float phi  =  -180.f + phi_inc * p;
-        float theta = -90.f + theta_inc * t;
-
+        float theta = theta_inc * t;
+        if (p == 0)
+        {
+          m_theta_values.push_back(theta);
+        }
+        
         const int i = p * m_theta + t;
 
         vtkm::rendering::Camera camera;
@@ -688,19 +694,6 @@ private:
 
       } // theta
     } // phi
-
-    for(int p = 0; p < m_phi; ++p)
-    {
-      float phi  =  -180.f + phi_inc * p;
-      m_phi_values.push_back(phi);
-    }
-
-    for(int t = 0; t < m_theta; ++t)
-    {
-      float theta = -90.f + theta_inc * t;
-      m_theta_values.push_back(theta);
-    }
-
   }
 
 }; // CinemaManager


### PR DESCRIPTION
For theta in range [-90, +90] degrees, only positions on the upper hemisphere are created which leads to missing renderings from certain perspectives. For theta in range [0, 180] sample positions should cover the whole orbit.
![300px-Kugelkoord-def svg](https://user-images.githubusercontent.com/1810297/70817066-0bb4f380-1dd1-11ea-99b6-dd258c2a889a.png)
