### PR TITLE
change install dest for session converters [skip ci]

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -53,4 +53,4 @@ add_subdirectory(holo_compare)
 
 # install visit scripts
 install(DIRECTORY visit_session_converters
-        DESTINATION examples/visit_session_converters)
+        DESTINATION utilities/ascent/visit_session_converters)


### PR DESCRIPTION
small tweak to install python to make sure it lives under the ascent dir like other things.
