### PR TITLE
writing ghosts for doms with no windows

### DIFF
--- a/src/ascent/runtimes/ascent_main_runtime.cpp
+++ b/src/ascent/runtimes/ascent_main_runtime.cpp
@@ -1837,12 +1837,7 @@ void AscentRuntime::PaintNestsets()
         continue;
       }
 
-      std::string nest_name =  topo_nestsets[topo_name];
-
-      if(!dom.has_path("nestsets/"+nest_name))
-      {
-        continue;
-      }
+      std::string nest_name = topo_nestsets[topo_name];
 
       if(has_ghost)
       {
@@ -1866,7 +1861,7 @@ void AscentRuntime::PaintNestsets()
 
           conduit::Node &ghost_field = dom[ghost_path];
 
-          runtime::expressions::paint_nestsets(nest_name, dom, ghost_field);
+          runtime::expressions::paint_nestsets(nest_name, topo_name,  dom, ghost_field);
         }
         else
         {
@@ -1881,7 +1876,7 @@ void AscentRuntime::PaintNestsets()
         std::string ghost_name = topo_name + "_ghosts";
         conduit::Node &field = dom["fields/" + ghost_name];
         field.reset();
-        runtime::expressions::paint_nestsets(nest_name, dom, field);
+        runtime::expressions::paint_nestsets(nest_name, topo_name, dom, field);
         new_ghosts.insert(ghost_name);
       }
     }

--- a/src/ascent/runtimes/expressions/ascent_blueprint_architect.cpp
+++ b/src/ascent/runtimes/expressions/ascent_blueprint_architect.cpp
@@ -2209,16 +2209,10 @@ get_state_var(const conduit::Node &dataset, const std::string &var_name)
 }
 
 void paint_nestsets(const std::string nestset_name,
+                    const std::string topo_name,
                     conduit::Node &dom,
                     conduit::Node &field)
 {
-  if(!dom.has_path("nestsets/"+nestset_name))
-  {
-    ASCENT_ERROR("No nestset with that name");
-  }
-
-  conduit::Node &nestset = dom["nestsets/"+nestset_name];
-  const std::string topo_name = nestset["topology"].as_string();
   const conduit::Node &topo = dom["topologies/"+topo_name];
 
   if(topo["type"].as_string() == "unstructured")
@@ -2270,7 +2264,6 @@ void paint_nestsets(const std::string nestset_name,
       ASCENT_ERROR("unknown coord type");
     }
   }
-  // ok, now paint
 
   conduit::int32 field_size = el_dims[0] * el_dims[1];
   if(is_3d)
@@ -2302,6 +2295,19 @@ void paint_nestsets(const std::string nestset_name,
       levels[i] = 0;
     }
   }
+  // its possible at the coarsest level that there are
+  // no windows and thus no nestsets. We need to add
+  // an all zero field so that ghost field is consistent
+  // across all domains
+  if(!dom.has_path("nestsets/"+nestset_name))
+  {
+    // we alrady init'd it to zero if its a new field, so we are good to go
+    // if it wasnt' a new field, it should already have the correct values
+    return;
+  }
+
+  // ok, now paint
+  conduit::Node &nestset = dom["nestsets/"+nestset_name];
 
   const int windows = nestset["windows"].number_of_children();
 

--- a/src/ascent/runtimes/expressions/ascent_blueprint_architect.hpp
+++ b/src/ascent/runtimes/expressions/ascent_blueprint_architect.hpp
@@ -150,6 +150,7 @@ conduit::Node quantile(const conduit::Node &cdf,
 
 // if the field node is empty, we will allocate space
 void paint_nestsets(const std::string nestset_name,
+                    const std::string topo_name,
                     conduit::Node &dom,
                     conduit::Node &field); // field to paint on
 };


### PR DESCRIPTION
resolves #645

Issue: some domains are lonely at the corner of the data set (i.e., there are no nest sets in that region). This will paint the ghost field on those domains to appease the visit.