### PR TITLE
protect against hangs from vtkm surprises

### DIFF
--- a/src/ascent/runtimes/ascent_vtkh_data_adapter.cpp
+++ b/src/ascent/runtimes/ascent_vtkh_data_adapter.cpp
@@ -74,6 +74,7 @@
 // other ascent includes
 #include <ascent_logging.hpp>
 #include <ascent_block_timer.hpp>
+#include <ascent_mpi_utils.hpp>
 #include <vtkh/utils/vtkm_array_utils.hpp>
 #include <vtkh/utils/vtkm_dataset_info.hpp>
 
@@ -2284,6 +2285,7 @@ void VTKHDataAdapter::VTKHCollectionToBlueprintDataSet(VTKHCollection *collectio
 {
   node.reset();
 
+  bool success = true;
   const int cycle = collection->cycle();
   const double time = collection->time();
   // we have to re-merge the domains so all domains with the same
@@ -2291,23 +2293,35 @@ void VTKHDataAdapter::VTKHCollectionToBlueprintDataSet(VTKHCollection *collectio
   std::map<int, std::map<std::string,vtkm::cont::DataSet>> domain_map;
   domain_map = collection->by_domain_id();
 
-  for(auto domain_it : domain_map)
+  try
   {
-    const int domain_id = domain_it.first;
-
-    conduit::Node &dom = node.append();
-    dom["state/domain_id"] = (int) domain_id;
-    dom["state/cycle"] = cycle;
-    dom["state/time"] = time;
-
-    for(auto topo_it : domain_it.second)
+    for(auto domain_it : domain_map)
     {
-      const std::string topo_name = topo_it.first;
-      vtkm::cont::DataSet &dataset = topo_it.second;
-      VTKHDataAdapter::VTKmToBlueprintDataSet(&dataset, dom, topo_name, zero_copy);
+      const int domain_id = domain_it.first;
+
+      conduit::Node &dom = node.append();
+      dom["state/domain_id"] = (int) domain_id;
+      dom["state/cycle"] = cycle;
+      dom["state/time"] = time;
+
+      for(auto topo_it : domain_it.second)
+      {
+        const std::string topo_name = topo_it.first;
+        vtkm::cont::DataSet &dataset = topo_it.second;
+        VTKHDataAdapter::VTKmToBlueprintDataSet(&dataset, dom, topo_name, zero_copy);
+      }
     }
   }
+  catch(...)
+  {
+    success = false;
+  }
 
+  success = global_agreement(success);
+  if(!success)
+  {
+    ASCENT_ERROR("Failed to convert vtkm data set to blueprint");
+  }
 }
 
 void
@@ -2316,17 +2330,31 @@ VTKHDataAdapter::VTKHToBlueprintDataSet(vtkh::DataSet *dset,
                                         bool zero_copy)
 {
   node.reset();
-  const int num_doms = dset->GetNumberOfDomains();
-  for(int i = 0; i < num_doms; ++i)
+  bool success = true;
+  try
   {
-    conduit::Node &dom = node.append();
-    vtkm::cont::DataSet vtkm_dom;
-    vtkm::Id domain_id;
-    int cycle = dset->GetCycle();
-    dset->GetDomain(i, vtkm_dom, domain_id);
-    VTKHDataAdapter::VTKmToBlueprintDataSet(&vtkm_dom,dom, "topo", zero_copy);
-    dom["state/domain_id"] = (int) domain_id;
-    dom["state/cycle"] = cycle;
+    const int num_doms = dset->GetNumberOfDomains();
+    for(int i = 0; i < num_doms; ++i)
+    {
+      conduit::Node &dom = node.append();
+      vtkm::cont::DataSet vtkm_dom;
+      vtkm::Id domain_id;
+      int cycle = dset->GetCycle();
+      dset->GetDomain(i, vtkm_dom, domain_id);
+      VTKHDataAdapter::VTKmToBlueprintDataSet(&vtkm_dom,dom, "topo", zero_copy);
+      dom["state/domain_id"] = (int) domain_id;
+      dom["state/cycle"] = cycle;
+    }
+  }
+  catch(...)
+  {
+    success = false;
+  }
+
+  success = global_agreement(success);
+  if(!success)
+  {
+    ASCENT_ERROR("Failed to convert vtkm data set to blueprint");
   }
 }
 


### PR DESCRIPTION
resolves #646

Wrap vtkm -> blueprint conversion to protect against mpi hangs when one conversion fails.