### PR TITLE
Skip unsupported fields

### DIFF
--- a/src/ascent/runtimes/ascent_vtkh_data_adapter.cpp
+++ b/src/ascent/runtimes/ascent_vtkh_data_adapter.cpp
@@ -2274,8 +2274,11 @@ VTKHDataAdapter::VTKmFieldToBlueprint(conduit::Node &output,
   }
   else
   {
-    field.PrintSummary(std::cerr);
-    ASCENT_ERROR("Field type unsupported for conversion");
+    std::stringstream msg;
+    msg<<"Field type unsupported for conversion: ";
+    field.PrintSummary(msg);
+    msg<<" Skipping.";
+    ASCENT_INFO(msg.str());
   }
 }
 

--- a/src/ascent/runtimes/ascent_vtkh_data_adapter.cpp
+++ b/src/ascent/runtimes/ascent_vtkh_data_adapter.cpp
@@ -2275,7 +2275,7 @@ VTKHDataAdapter::VTKmFieldToBlueprint(conduit::Node &output,
   else
   {
     std::stringstream msg;
-    msg<<"Field type unsupported for conversion: ";
+    msg<<"Field type unsupported for conversion to blueprint.\n";
     field.PrintSummary(msg);
     msg<<" Skipping.";
     ASCENT_INFO(msg.str());


### PR DESCRIPTION
Calling vorticity on a vector field adds the gradient to the output. The result is a `Vec<Vec<float,3>,3>` which we don't currently support converting to blueprint. Instead of throwing an error, just skip these fields and inform a human.