### PR TITLE
[WIP] fix ascent relay runtime for conduit-57702db

### DIFF
--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -254,40 +254,16 @@ void make_domain_ids(conduit::Node &domains)
 bool clean_mesh(const conduit::Node &data, conduit::Node &output)
 {
   output.reset();
-  const int potential_doms = data.number_of_children();
-  bool maybe_multi_dom = true;
 
-  if(!data.dtype().is_object() && !data.dtype().is_list())
+  conduit::Node info;
+  if(blueprint::mesh::verify(data, info))
   {
-    maybe_multi_dom = false;
-  }
-
-  if(maybe_multi_dom)
-  {
-    // check all the children for valid domains
-    for(int i = 0; i < potential_doms; ++i)
+    const auto domains = blueprint::mesh::domains(data);
+    for(auto it = domains.cbegin(); it != domains.cend(); ++it)
     {
-      conduit::Node info;
-      const conduit::Node &child = data.child(i);
-      bool is_valid = blueprint::mesh::verify(child, info);
-      if(is_valid)
-      {
-        conduit::Node &dest_dom = output.append();
-        dest_dom.set_external(child);
-      }
-    }
-  }
-  // if there is nothing in the output, lets see if it is a
-  // valid single domain
-  if(output.number_of_children() == 0)
-  {
-    // check to see if this is a single valid domain
-    conduit::Node info;
-    bool is_valid = blueprint::mesh::verify(data, info);
-    if(is_valid)
-    {
+      const conduit::Node &src_dom = **it;
       conduit::Node &dest_dom = output.append();
-      dest_dom.set_external(data);
+      dest_dom.set_external(src_dom);
     }
   }
 


### PR DESCRIPTION
The changes in this pull request attempt to fix an issue with the Ascent/Relay runtime introduced by [conduit@57702db](https://github.com/LLNL/conduit/commit/57702db0ce35b5cbeaee31179659a88385d94bce), which changed the logic for `blueprint::mesh::verify` in a way that necessitates different handling for empty nodes. For a more complete overview of this issue/fix, see [conduit#752](https://github.com/LLNL/conduit/issues/752) for details on the Ascent issue and [conduit#731](https://github.com/LLNL/conduit/pull/731#issuecomment-814366371) for details on how Conduit has changed.

An important note about these changes: the new implementation isn't as lenient as the prior version, which may or may not be a problem. More specifically, the prior version performed domain-by-domain verification for multi-domain meshes and allowed through all valid domains. By contrast, the new version performs a bulk mesh verification and only passes through the constituent domains if the verification succeeds (i.e. all domains **must be valid**). If the Ascent Relay runtime needs to support cases with one or more invalid domains (i.e. `blueprint::mesh::verify(domain)` is `false`), then this fix needs to be reworked.