### PR TITLE
Add phi_range and theta_range to the cinema rendering options.

### DIFF
--- a/src/ascent/runtimes/flow_filters/ascent_runtime_rendering_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_rendering_filters.cpp
@@ -529,12 +529,12 @@ public:
     if(render_node.has_path("phi"))
     {
       m_phi_min = -180.0;
-      m_phi = render_node["phi"].as_int32();
+      m_phi = render_node["phi"].to_int32();
       m_phi_inc = 360.0 / double(m_phi);
     }
     else if(render_node.has_path("phi_range") && render_node.has_path("dphi"))
     {
-      const double *phi_range = render_node["phi_range"].as_float64_ptr();
+      float64_accessor phi_range = render_node["phi_range"].as_float64_accessor();
       if (phi_range[0] >= phi_range[1])
       {
         ASCENT_ERROR("Cinema camera phi_range[0] must be less that phi_range[1]");
@@ -545,13 +545,13 @@ public:
     }
     else if(render_node.has_path("phi_range") && render_node.has_path("phi_num_angles"))
     {
-      const double *phi_range = render_node["phi_range"].as_float64_ptr();
+      float64_accessor phi_range = render_node["phi_range"].as_float64_accessor();
       if (phi_range[0] >= phi_range[1])
       {
         ASCENT_ERROR("Cinema camera phi_range[0] must be less that phi_range[1]");
       }
       m_phi_min = phi_range[0];
-      m_phi = render_node["phi_num_angles"].as_int32();
+      m_phi = render_node["phi_num_angles"].to_int32();
       m_phi_inc =  (phi_range[1] - phi_range[0]) / double(m_phi - 1);
     }
     else
@@ -563,12 +563,12 @@ public:
     if(render_node.has_path("theta"))
     {
       m_theta_min = 0.0;
-      m_theta = render_node["theta"].as_int32();
+      m_theta = render_node["theta"].to_int32();
       m_theta_inc = 180.0 / double(m_theta);
     }
     else if(render_node.has_path("theta_range") && render_node.has_path("dtheta"))
     {
-      const double *theta_range = render_node["theta_range"].as_float64_ptr();
+      float64_accessor theta_range = render_node["theta_range"].as_float64_accessor();
       if (theta_range[0] >= theta_range[1])
       {
         ASCENT_ERROR("Cinema camera theta_range[0] must be less that theta_range[1]");
@@ -579,13 +579,13 @@ public:
     }
     else if(render_node.has_path("theta_range") && render_node.has_path("theta_num_angles"))
     {
-      const double *theta_range = render_node["theta_range"].as_float64_ptr();
+      float64_accessor theta_range = render_node["theta_range"].as_float64_accessor();
       if (theta_range[0] >= theta_range[1])
       {
         ASCENT_ERROR("Cinema camera theta_range[0] must be less that theta_range[1]");
       }
       m_theta_min = theta_range[0];
-      m_theta = render_node["theta_num_angles"].as_int32();
+      m_theta = render_node["theta_num_angles"].to_int32();
       m_theta_inc =  (theta_range[1] - theta_range[0]) / double(m_theta - 1);
     }
     else
@@ -1003,7 +1003,7 @@ DefaultRender::execute()
 
     if(meta.has_path("cycle"))
     {
-      cycle = meta["cycle"].as_int32();
+      cycle = meta["cycle"].to_int32();
     }
 
     // figure out if we need the original bounds for the scene

--- a/src/tests/ascent/t_ascent_cinema_a.cpp
+++ b/src/tests/ascent/t_ascent_cinema_a.cpp
@@ -412,6 +412,96 @@ TEST(ascent_cinema_a, test_angle_values)
 }
 
 //-----------------------------------------------------------------------------
+TEST(ascent_cinema_a, test_phi_theta_positions)
+{
+    // the vtkm runtime is currently our only rendering runtime
+    Node n;
+    ascent::about(n);
+    // only run this test if ascent was built with vtkm support
+    if(n["runtimes/ascent/vtkm/status"].as_string() == "disabled")
+    {
+        ASCENT_INFO("Ascent support disabled, skipping test");
+        return;
+    }
+
+    //
+    // Create example mesh.
+    //
+    Node data, verify_info;
+    conduit::blueprint::mesh::examples::braid("hexs",
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+    std::string db_name = "test_db5";
+    string output_path = "./cinema_databases/" + db_name;
+    string output_file = conduit::utils::join_file_path(output_path, "info.json");
+    // remove old file before rendering
+    if(conduit::utils::is_file(output_file))
+    {
+        conduit::utils::remove_file(output_file);
+    }
+
+    //
+    // Create the actions.
+    //
+    Node actions;
+
+    conduit::Node pipelines;
+    // pipeline 1
+    pipelines["pl1/f1/type"] = "contour";
+    // filter knobs
+    conduit::Node &contour_params = pipelines["pl1/f1/params"];
+    contour_params["field"] = "braid";
+    contour_params["iso_values"] = 0.;
+
+    conduit::Node scenes;
+    scenes["scene1/plots/plt1/type"] = "pseudocolor";
+    scenes["scene1/plots/plt1/pipeline"] = "pl1";
+    scenes["scene1/plots/plt1/field"] = "braid";
+    // setup required cinema params
+    scenes["scene1/renders/r1/type"] = "cinema";
+    scenes["scene1/renders/r1/phi_theta_positions"].set({   0.,   0.,
+                                                         -180.,  90.,
+                                                          -90.,  90.,
+                                                            0.,  90.,
+                                                           90.,  90.,
+                                                          180.,  90.,
+                                                            0., 180.});
+    scenes["scene1/renders/r1/db_name"] = "test_db5";
+    //scenes["scene1/renders/r1/annotations"] = "false";
+    scenes["scene1/renders/r1/camera/zoom"] = 1.0; // no zoom
+
+    // add the pipeline
+    conduit::Node &add_pipelines = actions.append();
+    add_pipelines["action"] = "add_pipelines";
+    add_pipelines["pipelines"] = pipelines;
+    // add scene
+    conduit::Node &add_scenes = actions.append();
+    add_scenes["action"] = "add_scenes";
+    add_scenes["scenes"] = scenes;
+    actions.print();
+
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+    Node ascent_opts;
+    // default is now ascent
+    ascent_opts["runtime/type"] = "ascent";
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    ascent.execute(actions);
+    ascent.close();
+
+    // check that we created an image
+    EXPECT_TRUE(conduit::utils::is_file(output_file));
+}
+
+//-----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     int result = 0;

--- a/src/tests/ascent/t_ascent_cinema_a.cpp
+++ b/src/tests/ascent/t_ascent_cinema_a.cpp
@@ -91,7 +91,7 @@ TEST(ascent_cinema_a, test_cinema_a)
                                                data);
 
     EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
-    std::string db_name = "test_db";
+    std::string db_name = "test_db1";
     string output_path = "./cinema_databases/" + db_name;
     string output_file = conduit::utils::join_file_path(output_path, "info.json");
     // remove old file before rendering
@@ -121,7 +121,181 @@ TEST(ascent_cinema_a, test_cinema_a)
     scenes["scene1/renders/r1/type"] = "cinema";
     scenes["scene1/renders/r1/phi"] = 2;
     scenes["scene1/renders/r1/theta"] = 2;
-    scenes["scene1/renders/r1/db_name"] = "test_db";
+    scenes["scene1/renders/r1/db_name"] = "test_db1";
+    //scenes["scene1/renders/r1/annotations"] = "false";
+    scenes["scene1/renders/r1/camera/zoom"] = 1.0; // no zoom
+
+    // add the pipeline
+    conduit::Node &add_pipelines = actions.append();
+    add_pipelines["action"] = "add_pipelines";
+    add_pipelines["pipelines"] = pipelines;
+    // add scene
+    conduit::Node &add_scenes = actions.append();
+    add_scenes["action"] = "add_scenes";
+    add_scenes["scenes"] = scenes;
+    actions.print();
+
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+    Node ascent_opts;
+    // default is now ascent
+    ascent_opts["runtime/type"] = "ascent";
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    ascent.execute(actions);
+    ascent.close();
+
+    // check that we created an image
+    EXPECT_TRUE(conduit::utils::is_file(output_file));
+}
+
+//-----------------------------------------------------------------------------
+TEST(ascent_cinema_a, test_angle_range_1)
+{
+    // the vtkm runtime is currently our only rendering runtime
+    Node n;
+    ascent::about(n);
+    // only run this test if ascent was built with vtkm support
+    if(n["runtimes/ascent/vtkm/status"].as_string() == "disabled")
+    {
+        ASCENT_INFO("Ascent support disabled, skipping test");
+        return;
+    }
+
+    //
+    // Create example mesh.
+    //
+    Node data, verify_info;
+    conduit::blueprint::mesh::examples::braid("hexs",
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+    std::string db_name = "test_db2";
+    string output_path = "./cinema_databases/" + db_name;
+    string output_file = conduit::utils::join_file_path(output_path, "info.json");
+    // remove old file before rendering
+    if(conduit::utils::is_file(output_file))
+    {
+        conduit::utils::remove_file(output_file);
+    }
+
+    //
+    // Create the actions.
+    //
+    Node actions;
+
+    conduit::Node pipelines;
+    // pipeline 1
+    pipelines["pl1/f1/type"] = "contour";
+    // filter knobs
+    conduit::Node &contour_params = pipelines["pl1/f1/params"];
+    contour_params["field"] = "braid";
+    contour_params["iso_values"] = 0.;
+
+    conduit::Node scenes;
+    scenes["scene1/plots/plt1/type"] = "pseudocolor";
+    scenes["scene1/plots/plt1/pipeline"] = "pl1";
+    scenes["scene1/plots/plt1/field"] = "braid";
+    // setup required cinema params
+    scenes["scene1/renders/r1/type"] = "cinema";
+    scenes["scene1/renders/r1/phi_range"].set({-180., 180.});
+    scenes["scene1/renders/r1/dphi"] = 90.;
+    scenes["scene1/renders/r1/theta_range"].set({0., 180.});
+    scenes["scene1/renders/r1/dtheta"] = 90.;
+    scenes["scene1/renders/r1/db_name"] = "test_db2";
+    //scenes["scene1/renders/r1/annotations"] = "false";
+    scenes["scene1/renders/r1/camera/zoom"] = 1.0; // no zoom
+
+    // add the pipeline
+    conduit::Node &add_pipelines = actions.append();
+    add_pipelines["action"] = "add_pipelines";
+    add_pipelines["pipelines"] = pipelines;
+    // add scene
+    conduit::Node &add_scenes = actions.append();
+    add_scenes["action"] = "add_scenes";
+    add_scenes["scenes"] = scenes;
+    actions.print();
+
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+    Node ascent_opts;
+    // default is now ascent
+    ascent_opts["runtime/type"] = "ascent";
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    ascent.execute(actions);
+    ascent.close();
+
+    // check that we created an image
+    EXPECT_TRUE(conduit::utils::is_file(output_file));
+}
+
+//-----------------------------------------------------------------------------
+TEST(ascent_cinema_a, test_angle_range_2)
+{
+    // the vtkm runtime is currently our only rendering runtime
+    Node n;
+    ascent::about(n);
+    // only run this test if ascent was built with vtkm support
+    if(n["runtimes/ascent/vtkm/status"].as_string() == "disabled")
+    {
+        ASCENT_INFO("Ascent support disabled, skipping test");
+        return;
+    }
+
+    //
+    // Create example mesh.
+    //
+    Node data, verify_info;
+    conduit::blueprint::mesh::examples::braid("hexs",
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+    std::string db_name = "test_db3";
+    string output_path = "./cinema_databases/" + db_name;
+    string output_file = conduit::utils::join_file_path(output_path, "info.json");
+    // remove old file before rendering
+    if(conduit::utils::is_file(output_file))
+    {
+        conduit::utils::remove_file(output_file);
+    }
+
+    //
+    // Create the actions.
+    //
+    Node actions;
+
+    conduit::Node pipelines;
+    // pipeline 1
+    pipelines["pl1/f1/type"] = "contour";
+    // filter knobs
+    conduit::Node &contour_params = pipelines["pl1/f1/params"];
+    contour_params["field"] = "braid";
+    contour_params["iso_values"] = 0.;
+
+    conduit::Node scenes;
+    scenes["scene1/plots/plt1/type"] = "pseudocolor";
+    scenes["scene1/plots/plt1/pipeline"] = "pl1";
+    scenes["scene1/plots/plt1/field"] = "braid";
+    // setup required cinema params
+    scenes["scene1/renders/r1/type"] = "cinema";
+    scenes["scene1/renders/r1/phi_range"].set({-180., 180.});
+    scenes["scene1/renders/r1/phi_num_angles"] = 5;
+    scenes["scene1/renders/r1/theta_range"].set({0., 180.});
+    scenes["scene1/renders/r1/theta_num_angles"] = 3;
+    scenes["scene1/renders/r1/db_name"] = "test_db3";
     //scenes["scene1/renders/r1/annotations"] = "false";
     scenes["scene1/renders/r1/camera/zoom"] = 1.0; // no zoom
 

--- a/src/tests/ascent/t_ascent_cinema_a.cpp
+++ b/src/tests/ascent/t_ascent_cinema_a.cpp
@@ -463,13 +463,15 @@ TEST(ascent_cinema_a, test_phi_theta_positions)
     scenes["scene1/plots/plt1/field"] = "braid";
     // setup required cinema params
     scenes["scene1/renders/r1/type"] = "cinema";
-    scenes["scene1/renders/r1/phi_theta_positions"].set({   0.,   0.,
-                                                         -180.,  90.,
-                                                          -90.,  90.,
-                                                            0.,  90.,
-                                                           90.,  90.,
-                                                          180.,  90.,
-                                                            0., 180.});
+    conduit::Node positions;
+    positions.append().set({   0.,   0.});
+    positions.append().set({-180.,  90.});
+    positions.append().set({ -90.,  90.});
+    positions.append().set({   0.,  90.});
+    positions.append().set({  90.,  90.});
+    positions.append().set({ 180.,  90.});
+    positions.append().set({   0., 180.});
+    scenes["scene1/renders/r1/phi_theta_positions"] = positions;
     scenes["scene1/renders/r1/db_name"] = "test_db5";
     //scenes["scene1/renders/r1/annotations"] = "false";
     scenes["scene1/renders/r1/camera/zoom"] = 1.0; // no zoom

--- a/src/tests/ascent/t_ascent_cinema_a.cpp
+++ b/src/tests/ascent/t_ascent_cinema_a.cpp
@@ -327,6 +327,91 @@ TEST(ascent_cinema_a, test_angle_range_2)
 }
 
 //-----------------------------------------------------------------------------
+TEST(ascent_cinema_a, test_angle_values)
+{
+    // the vtkm runtime is currently our only rendering runtime
+    Node n;
+    ascent::about(n);
+    // only run this test if ascent was built with vtkm support
+    if(n["runtimes/ascent/vtkm/status"].as_string() == "disabled")
+    {
+        ASCENT_INFO("Ascent support disabled, skipping test");
+        return;
+    }
+
+    //
+    // Create example mesh.
+    //
+    Node data, verify_info;
+    conduit::blueprint::mesh::examples::braid("hexs",
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               EXAMPLE_MESH_SIDE_DIM,
+                                               data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+    std::string db_name = "test_db4";
+    string output_path = "./cinema_databases/" + db_name;
+    string output_file = conduit::utils::join_file_path(output_path, "info.json");
+    // remove old file before rendering
+    if(conduit::utils::is_file(output_file))
+    {
+        conduit::utils::remove_file(output_file);
+    }
+
+    //
+    // Create the actions.
+    //
+    Node actions;
+
+    conduit::Node pipelines;
+    // pipeline 1
+    pipelines["pl1/f1/type"] = "contour";
+    // filter knobs
+    conduit::Node &contour_params = pipelines["pl1/f1/params"];
+    contour_params["field"] = "braid";
+    contour_params["iso_values"] = 0.;
+
+    conduit::Node scenes;
+    scenes["scene1/plots/plt1/type"] = "pseudocolor";
+    scenes["scene1/plots/plt1/pipeline"] = "pl1";
+    scenes["scene1/plots/plt1/field"] = "braid";
+    // setup required cinema params
+    scenes["scene1/renders/r1/type"] = "cinema";
+    scenes["scene1/renders/r1/phi_angles"].set({-180., -90., 0., 90., 180.});
+    scenes["scene1/renders/r1/theta_angles"].set({0., 90., 180.});
+    scenes["scene1/renders/r1/db_name"] = "test_db4";
+    //scenes["scene1/renders/r1/annotations"] = "false";
+    scenes["scene1/renders/r1/camera/zoom"] = 1.0; // no zoom
+
+    // add the pipeline
+    conduit::Node &add_pipelines = actions.append();
+    add_pipelines["action"] = "add_pipelines";
+    add_pipelines["pipelines"] = pipelines;
+    // add scene
+    conduit::Node &add_scenes = actions.append();
+    add_scenes["action"] = "add_scenes";
+    add_scenes["scenes"] = scenes;
+    actions.print();
+
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+    Node ascent_opts;
+    // default is now ascent
+    ascent_opts["runtime/type"] = "ascent";
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    ascent.execute(actions);
+    ascent.close();
+
+    // check that we created an image
+    EXPECT_TRUE(conduit::utils::is_file(output_file));
+}
+
+//-----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     int result = 0;


### PR DESCRIPTION
This resolves https://github.com/Alpine-DAV/ascent/issues/828

I added `phi_range` and `theta_range` to the cinema rendering options. Here are examples of using the new options.

```
    scenes["scene1/renders/r1/type"] = "cinema";
    scenes["scene1/renders/r1/phi_range"].set({-180., 180.});
    scenes["scene1/renders/r1/dphi"] = 90.;
    scenes["scene1/renders/r1/theta_range"].set({0., 180.});
    scenes["scene1/renders/r1/dtheta"] = 90.;
```

This results in the following angles:
phi: -180, -90, 0, 90, 180
theta: 0, 90, 180

```
    scenes["scene1/renders/r1/type"] = "cinema";
    scenes["scene1/renders/r1/phi_range"].set({-180., 180.});
    scenes["scene1/renders/r1/phi_num_angles"] = 5;
    scenes["scene1/renders/r1/theta_range"].set({0., 180.});
    scenes["scene1/renders/r1/theta_num_angles"] = 3;
```

This also results in the same angles as above:
phi: -180, -90, 0, 90, 180
theta: 0, 90, 180

I added a couple of tests with these new options in `src/tests/ascent/t_ascent_cinema_a.cpp`.

I didn't update the documentation, since I believe the existing documentation isn't completely correct in the description of `phi` and `theta`. I'm not sure if the documentation should be fixed or if the code should be changed. Once the correct action is determined, then I will update the documentation.