### PR TITLE
Add blueprint partition and flatten 

### DIFF
--- a/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
@@ -21,6 +21,7 @@
 #include <conduit.hpp>
 #include <conduit_relay.hpp>
 #include <conduit_blueprint.hpp>
+#include <conduit_blueprint_mesh.hpp>
 
 //-----------------------------------------------------------------------------
 // ascent includes

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
@@ -207,11 +207,11 @@ BlueprintPartition::verify_params(const conduit::Node &params,
     info.reset();
     bool res = true;
 
-//    if(params.has_child("selections") )
-//    {
-//        const int num_selections = params["selections"].number_of_children();
-//	  if(num_selections 
-//    }
+    if(! params.has_child("target") ||
+       ! params["target"].dtype().is_int() )
+    {
+        info["errors"].append() = "Missing required int parameter 'target'";
+    }
 
     return res;
 }
@@ -232,18 +232,13 @@ BlueprintPartition::execute()
     conduit::Node n_output;
     
     conduit::Node n_options = params();
-    //if(params().has_child("selections"))
-    //{
-    //    conduit::Node n_selections = params()["selections"];
-    //    n_options.append(n_selections);
-    //}
 
 #ifdef ASCENT_MPI_ENABLED
     MPI_Comm mpi_comm = MPI_Comm_f2c(flow::Workspace::default_mpi_comm());
-//    conduit::blueprint::mpi::mesh::partition(*n_input,
-//		    			     n_options,
-//					     n_output,
-//					     mpi_comm);
+    conduit::blueprint::mpi::mesh::partition(*n_input,
+		    			     n_options,
+					     n_output,
+					     mpi_comm);
 #else
     conduit::blueprint::mesh::partition(*n_input,
 		     		        n_options,

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
@@ -232,6 +232,8 @@ BlueprintPartition::execute()
     conduit::Node n_output;
     
     conduit::Node n_options = params();
+//    std::cerr << "before partition:" << std::endl;
+//    n_input->print();
 
 #ifdef ASCENT_MPI_ENABLED
     MPI_Comm mpi_comm = MPI_Comm_f2c(flow::Workspace::default_mpi_comm());
@@ -244,9 +246,11 @@ BlueprintPartition::execute()
 		     		        n_options,
 					n_output);
 #endif
-
+//    std::cerr << "after partition:" << std::endl;
+//    n_output.print();
     DataObject *d_output = new DataObject(&n_output);
     set_output<DataObject>(d_output);
+ //   set_output<DataObject>(d_input);
 }
 //-----------------------------------------------------------------------------
 DataBinning::DataBinning()

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
@@ -37,6 +37,8 @@
 // mpi
 #ifdef ASCENT_MPI_ENABLED
 #include <mpi.h>
+#include <conduit_blueprint_mpi_mesh.hpp>
+#include <conduit_blueprint_mpi.hpp>
 #endif
 
 #if defined(ASCENT_VTKM_ENABLED)
@@ -174,6 +176,82 @@ BlueprintVerify::execute()
     set_output<DataObject>(d_input);
 }
 
+//-----------------------------------------------------------------------------
+BlueprintPartition::BlueprintPartition()
+:Filter()
+{
+// empty
+}
+
+//-----------------------------------------------------------------------------
+BlueprintPartition::~BlueprintPartition()
+{
+// empty
+}
+
+//-----------------------------------------------------------------------------
+void
+BlueprintPartition::declare_interface(Node &i)
+{
+    i["type_name"]   = "blueprint_data_partition";
+    i["port_names"].append() = "in";
+    i["output_port"] = "true";
+}
+
+//-----------------------------------------------------------------------------
+bool
+BlueprintPartition::verify_params(const conduit::Node &params,
+                               conduit::Node &info)
+{
+    info.reset();
+    bool res = true;
+
+//    if(params.has_child("selections") )
+//    {
+//        const int num_selections = params["selections"].number_of_children();
+//	  if(num_selections 
+//    }
+
+    return res;
+}
+
+
+//-----------------------------------------------------------------------------
+void
+BlueprintPartition::execute()
+{
+    if(!input(0).check_type<DataObject>())
+    {
+        ASCENT_ERROR("blueprint_data_partition input must be a DataObject");
+    }
+
+    DataObject *d_input = input<DataObject>(0);
+    std::shared_ptr<conduit::Node> n_input = d_input->as_node();
+
+    conduit::Node n_output;
+    
+    conduit::Node n_options = params();
+    //if(params().has_child("selections"))
+    //{
+    //    conduit::Node n_selections = params()["selections"];
+    //    n_options.append(n_selections);
+    //}
+
+#ifdef ASCENT_MPI_ENABLED
+    MPI_Comm mpi_comm = MPI_Comm_f2c(flow::Workspace::default_mpi_comm());
+//    conduit::blueprint::mpi::mesh::partition(*n_input,
+//		    			     n_options,
+//					     n_output,
+//					     mpi_comm);
+#else
+    conduit::blueprint::mesh::partition(*n_input,
+		     		        n_options,
+					n_output);
+#endif
+
+    DataObject *d_output = new DataObject(&n_output);
+    set_output<DataObject>(d_output);
+}
 //-----------------------------------------------------------------------------
 DataBinning::DataBinning()
 :Filter()

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.cpp
@@ -229,28 +229,23 @@ BlueprintPartition::execute()
     DataObject *d_input = input<DataObject>(0);
     std::shared_ptr<conduit::Node> n_input = d_input->as_node();
 
-    conduit::Node n_output;
+    conduit::Node *n_output = new conduit::Node();
     
     conduit::Node n_options = params();
-//    std::cerr << "before partition:" << std::endl;
-//    n_input->print();
 
 #ifdef ASCENT_MPI_ENABLED
     MPI_Comm mpi_comm = MPI_Comm_f2c(flow::Workspace::default_mpi_comm());
     conduit::blueprint::mpi::mesh::partition(*n_input,
 		    			     n_options,
-					     n_output,
+					     *n_output,
 					     mpi_comm);
 #else
     conduit::blueprint::mesh::partition(*n_input,
 		     		        n_options,
-					n_output);
+					*n_output);
 #endif
-//    std::cerr << "after partition:" << std::endl;
-//    n_output.print();
-    DataObject *d_output = new DataObject(&n_output);
+    DataObject *d_output = new DataObject(n_output);
     set_output<DataObject>(d_output);
- //   set_output<DataObject>(d_input);
 }
 //-----------------------------------------------------------------------------
 DataBinning::DataBinning()

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.hpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_blueprint_filters.hpp
@@ -57,6 +57,19 @@ public:
 };
 
 //-----------------------------------------------------------------------------
+class ASCENT_API BlueprintPartition : public ::flow::Filter
+{
+public:
+    BlueprintPartition();
+   ~BlueprintPartition();
+
+    virtual void   declare_interface(conduit::Node &i);
+    virtual bool   verify_params(const conduit::Node &params,
+                                 conduit::Node &info);
+    virtual void   execute();
+};
+
+//-----------------------------------------------------------------------------
 class ASCENT_API DataBinning : public ::flow::Filter
 {
 public:

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_filters.cpp
@@ -83,6 +83,7 @@ void
 register_builtin()
 {
     AscentRuntime::register_filter_type<BlueprintVerify>();
+    AscentRuntime::register_filter_type<BlueprintFlatten>("extracts","flatten");
     AscentRuntime::register_filter_type<RelayIOSave>("extracts","relay");
     AscentRuntime::register_filter_type<RelayIOLoad>();
 

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_filters.cpp
@@ -95,6 +95,8 @@ register_builtin()
     AscentRuntime::register_filter_type<FilterQuery>("transforms","expression");
 
     AscentRuntime::register_filter_type<DataBinning>("transforms","binning");
+    
+    AscentRuntime::register_filter_type<BlueprintPartition>("transforms","partition");
 
 #if defined(ASCENT_VTKM_ENABLED)
     AscentRuntime::register_filter_type<DefaultRender>();

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -1365,17 +1365,17 @@ BlueprintFlatten::execute()
         if(protocol.empty())
         {
             path = path + ".csv";
-            conduit::relay::io::save(selected,path,params());
+            conduit::relay::io::save(output,path);
             result_path = path;
         }
         else if( protocol == "blueprint/mesh/hdf5" || protocol == "hdf5")
         {
-            conduit::relay::io::save(selected,path,protocol);
+            conduit::relay::io::save(output,path,protocol);
         }
         else
         {
             path = path + ".csv";
-            conduit::relay::io::write_csv(selected,path,params());
+            conduit::relay::io::save(output,path);
             result_path = path;
         }
     }

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -1311,7 +1311,6 @@ BlueprintFlatten::execute()
     std::shared_ptr<Node> n_input = data_object->as_node();
 
     Node *in = n_input.get();
-
     Node selected;
     if(params().has_path("fields"))
     {
@@ -1364,6 +1363,7 @@ BlueprintFlatten::execute()
     {
         if(protocol.empty())
         {
+            //path = path;
             path = path + ".csv";
             conduit::relay::io::save(output,path);
             result_path = path;

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -22,7 +22,6 @@
 #include <conduit_relay.hpp>
 #include <conduit_blueprint.hpp>
 #include <conduit_blueprint_mesh.hpp>
-#include <conduit_relay_io_csv.hpp>
 
 //-----------------------------------------------------------------------------
 // ascent includes

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -1269,7 +1269,17 @@ bool
 BlueprintFlatten::verify_params(const conduit::Node &params,
                            conduit::Node &info)
 {
-    return verify_io_params(params,info);
+    info.reset();
+    bool res = true;
+
+    if(! params.has_child("protocol") ||
+       ! params["protocol"].dtype().is_int() )
+    {
+        info["errors"].append() = "Missing required string parameter 'protocol'";
+    }
+
+    return res;
+    //return verify_io_params(params,info);
 }
 
 
@@ -1330,10 +1340,10 @@ BlueprintFlatten::execute()
     Node output;
 #ifdef ASCENT_MPI_ENABLED
     MPI_Comm mpi_comm = MPI_Comm_f2c(flow::Workspace::default_mpi_comm());
-//    blueprint::mpi::mesh::flatten(selected,
-//		                  params(),
-//				  output,
-//  				  mpi_comm);
+    blueprint::mpi::mesh::flatten(selected,
+		                  params(),
+				  output,
+  				  mpi_comm);
 #else
     blueprint::mesh::flatten(selected,
 		             params(),

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -21,6 +21,7 @@
 #include <conduit.hpp>
 #include <conduit_relay.hpp>
 #include <conduit_blueprint.hpp>
+#include <conduit_blueprint_mesh.hpp>
 
 //-----------------------------------------------------------------------------
 // ascent includes
@@ -41,6 +42,7 @@
 #include <mpi.h>
 // -- conduit relay mpi
 #include <conduit_relay_mpi.hpp>
+#include <conduit_blueprint_mpi_mesh.hpp>
 #endif
 
 // std includes
@@ -1240,6 +1242,167 @@ RelayIOLoad::execute()
     set_output<Node>(res);
 
 }
+//-----------------------------------------------------------------------------
+BlueprintFlatten::BlueprintFlatten()
+:Filter()
+{
+// empty
+}
+
+//-----------------------------------------------------------------------------
+BlueprintFlatten::~BlueprintFlatten()
+{
+// empty
+}
+
+//-----------------------------------------------------------------------------
+void
+BlueprintFlatten::declare_interface(Node &i)
+{
+    i["type_name"]   = "false";
+    i["port_names"].append() = "in";
+    i["output_port"] = "false";
+}
+
+//-----------------------------------------------------------------------------
+bool
+BlueprintFlatten::verify_params(const conduit::Node &params,
+                           conduit::Node &info)
+{
+    return verify_io_params(params,info);
+}
+
+
+//-----------------------------------------------------------------------------
+void
+BlueprintFlatten::execute()
+{
+    std::string path, protocol;
+    path = params()["path"].as_string();
+    path = output_dir(path);
+
+    if(params().has_child("protocol"))
+    {
+        protocol = params()["protocol"].as_string();
+    }
+
+    if(!input("in").check_type<DataObject>())
+    {
+        // error
+        ASCENT_ERROR("Blueprint flatten requires a DataObject input");
+    }
+
+    DataObject *data_object  = input<DataObject>("in");
+    if(!data_object->is_valid())
+    {
+      return;
+    }
+    std::shared_ptr<Node> n_input = data_object->as_node();
+
+    Node *in = n_input.get();
+
+    Node selected;
+    if(params().has_path("fields"))
+    {
+      std::vector<std::string> field_selection;
+      const conduit::Node &flist = params()["fields"];
+      const int num_fields = flist.number_of_children();
+      if(num_fields == 0)
+      {
+        ASCENT_ERROR("Blueprint flatten field selection list must be non-empty");
+      }
+      for(int i = 0; i < num_fields; ++i)
+      {
+        const conduit::Node &f = flist.child(i);
+        if(!f.dtype().is_string())
+        {
+           ASCENT_ERROR("Blueprint flatten field selection list values must be a string");
+        }
+        field_selection.push_back(f.as_string());
+      }
+      detail::filter_fields(*in, selected, field_selection, graph());
+    }
+    else
+    {
+      // select all fields
+      selected.set_external(*in);
+    }
+    Node output;
+#ifdef ASCENT_MPI_ENABLED
+    MPI_Comm mpi_comm = MPI_Comm_f2c(flow::Workspace::default_mpi_comm());
+//    blueprint::mpi::mesh::flatten(selected,
+//		                  params(),
+//				  output,
+//  				  mpi_comm);
+#else
+    blueprint::mesh::flatten(selected,
+		             params(),
+			     output);
+
+#endif
+    int num_files = -1;
+
+    if(params().has_path("num_files"))
+    {
+        num_files = params()["num_files"].to_int();
+    }
+
+    std::string result_path;
+    if(protocol.empty())
+    {
+        conduit::relay::io::save(selected,path);
+        result_path = path;
+    }
+    else if( protocol == "blueprint/mesh/hdf5" || protocol == "hdf5")
+    {
+        mesh_blueprint_save(selected,
+                            path,
+                            "hdf5",
+                            num_files,
+                            result_path);
+    }
+    else if( protocol == "blueprint/mesh/json" || protocol == "json")
+    {
+        mesh_blueprint_save(selected,
+                            path,
+                            "json",
+                            num_files,
+                            result_path);
+
+    }
+    else if( protocol == "blueprint/mesh/yaml" || protocol == "yaml")
+    {
+        mesh_blueprint_save(selected,
+                            path,
+                            "yaml",
+                            num_files,
+                            result_path);
+
+    }
+    else
+    {
+        conduit::relay::io::save(selected,path,protocol);
+        result_path = path;
+    }
+
+    // add this to the extract results in the registry
+    if(!graph().workspace().registry().has_entry("extract_list"))
+    {
+      conduit::Node *extract_list = new conduit::Node();
+      graph().workspace().registry().add<Node>("extract_list",
+                                               extract_list,
+                                               -1); // TODO keep forever?
+    }
+
+    conduit::Node *extract_list = graph().workspace().registry().fetch<Node>("extract_list");
+
+    Node &einfo = extract_list->append();
+    einfo["type"] = "relay";
+    if(!protocol.empty())
+        einfo["protocol"] = protocol;
+    einfo["path"] = result_path;
+}
+
 
 //-----------------------------------------------------------------------------
 };

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.cpp
@@ -1368,15 +1368,10 @@ BlueprintFlatten::execute()
             conduit::relay::io::save(output,path);
             result_path = path;
         }
-        else if( protocol == "blueprint/mesh/hdf5" || protocol == "hdf5")
-        {
-            conduit::relay::io::save(output,path,protocol);
-        }
         else
         {
-            path = path + ".csv";
-            conduit::relay::io::save(output,path);
-            result_path = path;
+            conduit::relay::io::save(output,path,protocol);
+	    result_path = path;
         }
     }
 

--- a/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.hpp
+++ b/src/ascent/runtimes/flow_filters/ascent_runtime_relay_filters.hpp
@@ -73,6 +73,20 @@ public:
                                  conduit::Node &info);
     virtual void   execute();
 };
+//-----------------------------------------------------------------------------
+class ASCENT_API BlueprintFlatten : public ::flow::Filter
+{
+public:
+    BlueprintFlatten();
+   ~BlueprintFlatten();
+
+    virtual void   declare_interface(conduit::Node &i);
+    virtual bool   verify_params(const conduit::Node &params,
+                                 conduit::Node &info);
+    virtual void   execute();
+};
+
+//-----------------------------------------------------------------------------
 
 };
 //-----------------------------------------------------------------------------

--- a/src/cmake/thirdparty/SetupConduit.cmake
+++ b/src/cmake/thirdparty/SetupConduit.cmake
@@ -121,6 +121,6 @@ blt_register_library( NAME conduit
 if(MPI_FOUND)
     blt_register_library( NAME conduit_relay_mpi
                           INCLUDES ${CONDUIT_INCLUDE_DIRS}
-                          LIBRARIES  conduit_relay_mpi)
+                          LIBRARIES  conduit_relay_mpi conduit_blueprint_mpi)
 endif()
 

--- a/src/config/ascent_setup_targets.cmake
+++ b/src/config/ascent_setup_targets.cmake
@@ -77,7 +77,7 @@ if(ASCENT_MPI_ENABLED)
 
         set_property(TARGET ascent::ascent_mpi
                      APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     conduit conduit_relay conduit_relay_mpi conduit_blueprint)
+                     conduit conduit_relay conduit_relay_mpi conduit_blueprint conduit_blueprint_mpi)
     endif()
 
     if(ASCENT_VTKH_ENABLED)

--- a/src/tests/ascent/CMakeLists.txt
+++ b/src/tests/ascent/CMakeLists.txt
@@ -64,6 +64,7 @@ set(MPI_TESTS  t_ascent_mpi_smoke
                t_ascent_mpi_derived
                t_ascent_mpi_expressions
 	       t_ascent_mpi_flatten
+	       t_ascent_mpi_partition
                t_ascent_mpi_render_2d
                t_ascent_mpi_render_3d
                t_ascent_mpi_statistics

--- a/src/tests/ascent/CMakeLists.txt
+++ b/src/tests/ascent/CMakeLists.txt
@@ -34,6 +34,8 @@ set(BASIC_TESTS t_ascent_smoke
                 t_ascent_divergence
                 t_ascent_vorticity
                 t_ascent_relay
+		t_ascent_flatten
+		t_ascent_partition
                 t_ascent_clip_with_field
                 t_ascent_contour
                 t_ascent_iso_volume
@@ -61,6 +63,7 @@ set(MPI_TESTS  t_ascent_mpi_smoke
                t_ascent_mpi_empty_runtime
                t_ascent_mpi_derived
                t_ascent_mpi_expressions
+	       t_ascent_mpi_flatten
                t_ascent_mpi_render_2d
                t_ascent_mpi_render_3d
                t_ascent_mpi_statistics

--- a/src/tests/ascent/t_ascent_flatten.cpp
+++ b/src/tests/ascent/t_ascent_flatten.cpp
@@ -1,0 +1,116 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other Ascent
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Ascent.
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_ascent_flatten.cpp
+///
+//-----------------------------------------------------------------------------
+
+
+#include "gtest/gtest.h"
+
+#include <ascent.hpp>
+
+#include <iostream>
+#include <math.h>
+
+#include <conduit_blueprint.hpp>
+#include <conduit_relay.hpp>
+
+#include "t_config.hpp"
+#include "t_utils.hpp"
+
+
+using namespace std;
+using namespace conduit;
+using namespace ascent;
+
+//-----------------------------------------------------------------------------
+TEST(ascent_flatten, test_flatten_2D_multi_dom)
+{
+    Node n;
+    ascent::about(n);
+
+    //
+    // Create an example mesh.
+    //
+    Node data, verify_info;
+
+    // use spiral , with 7 domains
+    conduit::blueprint::mesh::examples::spiral(7,data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+
+    ASCENT_INFO("Testing blueprint flatten of multi-domain mesh in serial");
+
+    string output_path = prepare_output_dir();
+    std::ostringstream oss;
+
+    oss << "tout_flatten_multi_dom_serial";
+    string output_base = conduit::utils::join_file_path(output_path,
+                                                        oss.str());
+    oss << ".csv";
+    string output_dir = conduit::utils::join_file_path(output_path,
+                                                        oss.str());
+    std::ostringstream voss,eoss;
+    voss << "vertex_data.csv";
+    string output_vertex = conduit::utils::join_file_path(output_dir,
+		    					   voss.str());
+    eoss << "element_data.csv";
+    string output_element = conduit::utils::join_file_path(output_dir,
+		    					    eoss.str());
+    // remove existing directory
+    if(utils::is_directory(output_dir))
+    {
+        utils::remove_directory(output_dir);
+    }
+
+    conduit::Node actions;
+    // add the extracts
+    conduit::Node &add_extracts = actions.append();
+    add_extracts["action"] = "add_extracts";
+    conduit::Node &extracts = add_extracts["extracts"];
+
+    extracts["e1/type"]  = "flatten";
+    extracts["e1/params/path"] = output_base;
+
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+
+    Node ascent_opts;
+    ascent_opts["runtime"] = "ascent";
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    ascent.execute(actions);
+    ascent.close();
+
+    //A directory called tout_flatten_multi_dom_serial.csv 
+    EXPECT_TRUE(conduit::utils::is_directory(output_dir));
+    //Two files in above directory:
+    //vertex_data.csv
+    //element_data.csv
+    EXPECT_TRUE(conduit::utils::is_file(output_vertex));
+    EXPECT_TRUE(conduit::utils::is_file(output_element));
+
+}
+
+
+//-----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    int result = 0;
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    result = RUN_ALL_TESTS();
+    return result;
+}
+
+

--- a/src/tests/ascent/t_ascent_mpi_flatten.cpp
+++ b/src/tests/ascent/t_ascent_mpi_flatten.cpp
@@ -104,7 +104,7 @@ TEST(ascent_flatten, test_mpi_flatten_2D_multi_dom)
 
     //Root writes the files so a non-root rank could
     //check before files have been written and fail test
-    if(rank == 0)
+    if(par_rank == 0)
     {
     	//A directory called tout_flatten_multi_dom_serial.csv 
     	EXPECT_TRUE(conduit::utils::is_directory(output_dir));

--- a/src/tests/ascent/t_ascent_mpi_flatten.cpp
+++ b/src/tests/ascent/t_ascent_mpi_flatten.cpp
@@ -102,14 +102,18 @@ TEST(ascent_flatten, test_mpi_flatten_2D_multi_dom)
     ascent.execute(actions);
     ascent.close();
 
-    //A directory called tout_flatten_multi_dom_serial.csv 
-    EXPECT_TRUE(conduit::utils::is_directory(output_dir));
-    //Two files in above directory:
-    //vertex_data.csv
-    //element_data.csv
-    EXPECT_TRUE(conduit::utils::is_file(output_vertex));
-    EXPECT_TRUE(conduit::utils::is_file(output_element));
-
+    //Root writes the files so a non-root rank could
+    //check before files have been written and fail test
+    if(rank == 0)
+    {
+    	//A directory called tout_flatten_multi_dom_serial.csv 
+    	EXPECT_TRUE(conduit::utils::is_directory(output_dir));
+    	//Two files in above directory:
+    	//vertex_data.csv
+    	//element_data.csv
+    	EXPECT_TRUE(conduit::utils::is_file(output_vertex));
+    	EXPECT_TRUE(conduit::utils::is_file(output_element));
+    }
 }
 
 

--- a/src/tests/ascent/t_ascent_mpi_flatten.cpp
+++ b/src/tests/ascent/t_ascent_mpi_flatten.cpp
@@ -1,0 +1,129 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other Ascent
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Ascent.
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_ascent_mpi_flatten.cpp
+///
+//-----------------------------------------------------------------------------
+
+
+#include "gtest/gtest.h"
+
+#include <ascent.hpp>
+
+#include <iostream>
+#include <math.h>
+#include <mpi.h>
+
+#include <conduit_blueprint.hpp>
+#include <conduit_relay.hpp>
+
+#include "t_config.hpp"
+#include "t_utils.hpp"
+
+
+using namespace std;
+using namespace conduit;
+using namespace ascent;
+
+//-----------------------------------------------------------------------------
+TEST(ascent_flatten, test_mpi_flatten_2D_multi_dom)
+{
+    Node n;
+    ascent::about(n);
+    
+    //
+    //Set Up MPI
+    //
+    int par_rank;
+    int par_size;
+    MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(comm, &par_rank);
+    MPI_Comm_size(comm, &par_size);
+
+    //
+    // Create an example mesh.
+    //
+    Node data, verify_info;
+
+    // use spiral , with 7 domains
+    conduit::blueprint::mesh::examples::spiral(7,data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+
+    ASCENT_INFO("Testing blueprint flatten of multi-domain mesh with MPI");
+
+    string output_path = prepare_output_dir();
+    std::ostringstream oss;
+
+    oss << "tout_flatten_multi_dom_mpi";
+    string output_base = conduit::utils::join_file_path(output_path,
+                                                        oss.str());
+    oss << ".csv";
+    string output_dir = conduit::utils::join_file_path(output_path,
+                                                        oss.str());
+    std::ostringstream voss,eoss;
+    voss << "vertex_data.csv";
+    string output_vertex = conduit::utils::join_file_path(output_dir,
+		    					   voss.str());
+    eoss << "element_data.csv";
+    string output_element = conduit::utils::join_file_path(output_dir,
+		    					    eoss.str());
+    // remove existing directory
+    if(utils::is_directory(output_dir))
+    {
+        utils::remove_directory(output_dir);
+    }
+
+    conduit::Node actions;
+    // add the extracts
+    conduit::Node &add_extracts = actions.append();
+    add_extracts["action"] = "add_extracts";
+    conduit::Node &extracts = add_extracts["extracts"];
+
+    extracts["e1/type"]  = "flatten";
+    extracts["e1/params/path"] = output_base;
+
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+
+    Node ascent_opts;
+    ascent_opts["runtime"] = "ascent";
+    ascent_opts["mpi_comm"] = MPI_Comm_c2f(comm);
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    ascent.execute(actions);
+    ascent.close();
+
+    //A directory called tout_flatten_multi_dom_serial.csv 
+    EXPECT_TRUE(conduit::utils::is_directory(output_dir));
+    //Two files in above directory:
+    //vertex_data.csv
+    //element_data.csv
+    EXPECT_TRUE(conduit::utils::is_file(output_vertex));
+    EXPECT_TRUE(conduit::utils::is_file(output_element));
+
+}
+
+
+//-----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    int result = 0;
+
+    ::testing::InitGoogleTest(&argc, argv);
+    MPI_Init(&argc, &argv);
+
+    result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
+}
+
+

--- a/src/tests/ascent/t_ascent_mpi_partition.cpp
+++ b/src/tests/ascent/t_ascent_mpi_partition.cpp
@@ -69,7 +69,7 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     ossjson << "tout_partition_multi_dom_mpi_json";
     string output_json = conduit::utils::join_file_path(output_base,
 		    					ossjson.str());
-    // remove existing directory
+    // remove existing files
     if(par_rank == root)
     {
     	if(utils::is_file(output_base))

--- a/src/tests/ascent/t_ascent_partition.cpp
+++ b/src/tests/ascent/t_ascent_partition.cpp
@@ -79,12 +79,12 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     pipelines["pl1/f1/params/target"] = target;
     
     //add the extract
-    conduit::Node &add_extracts = actions.append();
-    add_extracts["action"] = "add_extracts";
-    conduit::Node &extracts = add_extracts["extracts"];
-    extracts["e1/type"] = "flatten";
-    extracts["e1/pipeline"] = "pl1";
-    extracts["e1/params/path"] = output_base;
+//    conduit::Node &add_extracts = actions.append();
+//    add_extracts["action"] = "add_extracts";
+//    conduit::Node &extracts = add_extracts["extracts"];
+//    extracts["e1/type"] = "flatten";
+//    extracts["e1/pipeline"] = "pl1";
+//    extracts["e1/params/path"] = output_base;
 
 
     actions.print();
@@ -98,11 +98,9 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     ascent_opts["runtime"] = "ascent";
     ascent.open(ascent_opts);
     ascent.publish(data);
-    cerr << "Before Ascent.execute()" << endl;
     ascent.execute(actions);
-    cerr << "After Ascent.execute()" << endl;
     ascent.close();
-cerr << "HERE IN TEST" << endl;
+
     //A directory called tout_partition_multi_dom_serial.csv 
     EXPECT_TRUE(conduit::utils::is_directory(output_dir));
     //Two files in above directory:

--- a/src/tests/ascent/t_ascent_partition.cpp
+++ b/src/tests/ascent/t_ascent_partition.cpp
@@ -79,12 +79,12 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     pipelines["pl1/f1/params/target"] = target;
     
     //add the extract
-//    conduit::Node &add_extracts = actions.append();
-//    add_extracts["action"] = "add_extracts";
-//    conduit::Node &extracts = add_extracts["extracts"];
-//    extracts["e1/type"] = "flatten";
-//    extracts["e1/pipeline"] = "pl1";
-//    extracts["e1/params/path"] = output_base;
+    conduit::Node &add_extracts = actions.append();
+    add_extracts["action"] = "add_extracts";
+    conduit::Node &extracts = add_extracts["extracts"];
+    extracts["e1/type"] = "flatten";
+    extracts["e1/pipeline"] = "pl1";
+    extracts["e1/params/path"] = output_base;
 
 
     actions.print();
@@ -110,9 +110,9 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     EXPECT_TRUE(conduit::utils::is_file(output_element));
     Node read_csv;
     conduit::relay::io::load(output_vertex,read_csv);
+
     int num_doms = conduit::blueprint::mesh::number_of_domains(read_csv);
-    //TODO: EDGE CASES???
-    EXPECT_TRUE(num_doms <= target);
+    EXPECT_TRUE(num_doms == target);
 }
 
 

--- a/src/tests/ascent/t_ascent_partition.cpp
+++ b/src/tests/ascent/t_ascent_partition.cpp
@@ -53,20 +53,18 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     oss << "tout_partition_multi_dom_serial";
     string output_base = conduit::utils::join_file_path(output_path,
                                                         oss.str());
-    oss << ".csv";
-    string output_dir = conduit::utils::join_file_path(output_path,
-                                                        oss.str());
-    std::ostringstream voss,eoss;
-    voss << "vertex_data.csv";
-    string output_vertex = conduit::utils::join_file_path(output_dir,
-		    					   voss.str());
-    eoss << "element_data.csv";
-    string output_element = conduit::utils::join_file_path(output_dir,
-		    					    eoss.str());
-    // remove existing directory
-    if(utils::is_directory(output_dir))
+    std::ostringstream ossjson;
+    ossjson << "tout_partition_multi_dom_serial_json";
+    string output_json = conduit::utils::join_file_path(output_base,
+		    					ossjson.str());
+    // remove existing file
+    if(utils::is_file(output_base))
     {
-        utils::remove_directory(output_dir);
+        utils::remove_file(output_base);
+    }
+    if(utils::is_file(output_json))
+    {
+        utils::remove_file(output_json);
     }
 
     conduit::Node actions;
@@ -82,7 +80,7 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     conduit::Node &add_extracts = actions.append();
     add_extracts["action"] = "add_extracts";
     conduit::Node &extracts = add_extracts["extracts"];
-    extracts["e1/type"] = "flatten";
+    extracts["e1/type"] = "relay";
     extracts["e1/pipeline"] = "pl1";
     extracts["e1/params/path"] = output_base;
 
@@ -99,15 +97,12 @@ TEST(ascent_partition, test_partition_2D_multi_dom)
     ascent.execute(actions);
     ascent.close();
 
-    //A directory called tout_partition_multi_dom_serial.csv 
-    EXPECT_TRUE(conduit::utils::is_directory(output_dir));
-    //Two files in above directory:
-    //vertex_data.csv
-    //element_data.csv
-    EXPECT_TRUE(conduit::utils::is_file(output_vertex));
-    EXPECT_TRUE(conduit::utils::is_file(output_element));
+    //Two files in _output directory:
+    //tout_partition_multi_dom_serial
+    //tout_partition_multi_dom_serial_json
+    EXPECT_TRUE(conduit::utils::is_file(output_base));
     Node read_csv;
-    conduit::relay::io::load(output_vertex,read_csv);
+    conduit::relay::io::load(output_base,read_csv);
 
     int num_doms = conduit::blueprint::mesh::number_of_domains(read_csv);
     EXPECT_TRUE(num_doms == target);

--- a/src/tests/ascent/t_ascent_partition.cpp
+++ b/src/tests/ascent/t_ascent_partition.cpp
@@ -1,0 +1,132 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other Ascent
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Ascent.
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_ascent_partition.cpp
+///
+//-----------------------------------------------------------------------------
+
+
+#include "gtest/gtest.h"
+
+#include <ascent.hpp>
+
+#include <iostream>
+#include <math.h>
+
+#include <conduit_blueprint.hpp>
+#include <conduit_relay.hpp>
+
+#include "t_config.hpp"
+#include "t_utils.hpp"
+
+
+using namespace std;
+using namespace conduit;
+using namespace ascent;
+
+//-----------------------------------------------------------------------------
+TEST(ascent_partition, test_partition_2D_multi_dom)
+{
+    Node n;
+    ascent::about(n);
+
+    //
+    // Create an example mesh.
+    //
+    Node data, verify_info;
+
+    // use spiral , with 7 domains
+    conduit::blueprint::mesh::examples::spiral(7,data);
+
+    EXPECT_TRUE(conduit::blueprint::mesh::verify(data,verify_info));
+
+    ASCENT_INFO("Testing blueprint partition of multi-domain mesh in serial");
+
+    string output_path = prepare_output_dir();
+    std::ostringstream oss;
+
+    oss << "tout_partition_multi_dom_serial";
+    string output_base = conduit::utils::join_file_path(output_path,
+                                                        oss.str());
+    oss << ".csv";
+    string output_dir = conduit::utils::join_file_path(output_path,
+                                                        oss.str());
+    std::ostringstream voss,eoss;
+    voss << "vertex_data.csv";
+    string output_vertex = conduit::utils::join_file_path(output_dir,
+		    					   voss.str());
+    eoss << "element_data.csv";
+    string output_element = conduit::utils::join_file_path(output_dir,
+		    					    eoss.str());
+    // remove existing directory
+    if(utils::is_directory(output_dir))
+    {
+        utils::remove_directory(output_dir);
+    }
+
+    conduit::Node actions;
+    int target = 1;
+    // add the pipeline
+    conduit::Node &add_pipelines = actions.append();
+    add_pipelines["action"] = "add_pipelines";
+    conduit::Node &pipelines = add_pipelines["pipelines"];
+    pipelines["pl1/f1/type"]  = "partition";
+    pipelines["pl1/f1/params/target"] = target;
+    
+    //add the extract
+    conduit::Node &add_extracts = actions.append();
+    add_extracts["action"] = "add_extracts";
+    conduit::Node &extracts = add_extracts["extracts"];
+    extracts["e1/type"] = "flatten";
+    extracts["e1/pipeline"] = "pl1";
+    extracts["e1/params/path"] = output_base;
+
+
+    actions.print();
+    //
+    // Run Ascent
+    //
+
+    Ascent ascent;
+
+    Node ascent_opts;
+    ascent_opts["runtime"] = "ascent";
+    ascent.open(ascent_opts);
+    ascent.publish(data);
+    cerr << "Before Ascent.execute()" << endl;
+    ascent.execute(actions);
+    cerr << "After Ascent.execute()" << endl;
+    ascent.close();
+cerr << "HERE IN TEST" << endl;
+    //A directory called tout_partition_multi_dom_serial.csv 
+    EXPECT_TRUE(conduit::utils::is_directory(output_dir));
+    //Two files in above directory:
+    //vertex_data.csv
+    //element_data.csv
+    EXPECT_TRUE(conduit::utils::is_file(output_vertex));
+    EXPECT_TRUE(conduit::utils::is_file(output_element));
+    Node read_csv;
+    conduit::relay::io::load(output_vertex,read_csv);
+    int num_doms = conduit::blueprint::mesh::number_of_domains(read_csv);
+    //TODO: EDGE CASES???
+    EXPECT_TRUE(num_doms <= target);
+}
+
+
+//-----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    int result = 0;
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    result = RUN_ALL_TESTS();
+    return result;
+}
+
+


### PR DESCRIPTION
Add the partition and flatten functionality provided by conduit blueprint to ascent as a pipeline and extract, respectively. Includes unit tests. 