### PR TITLE
Fixed uberenv submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/Alpine-DAV/spack_configs.git
 [submodule "scripts/uberenv"]
 	path = scripts/uberenv
-	url = https://github.com/llnl/uberenv/
+	url = https://github.com/LLNL/uberenv.git


### PR DESCRIPTION
When cloning the repo recursively or using Spack, I get this error:

Cloning into '/Users/vmateevitsi/src/alpine/ascent/scripts/uberenv'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Looks like the submodule url is incorrect, so this PR fixes that.