### PR TITLE
spack config changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   ubuntu_18_04_tag: alpinedav/ascent-ci:ubuntu-18.04-devel-tpls_2022-07-13-shabad8a7
   ubuntu_20_04_tag: alpinedav/ascent-ci:ubuntu-20.04-devel-tpls_2022-07-13-shabad8a7
   # TODO - on hold until we get spack working on 22.04
-  #ubuntu_22_04_tag: alpinedav/ascent-ci:ubuntu-22.04-devel-tpls_
+  #ubuntu_22_04_tag: alpinedav/ascent-ci:ubuntu-22.04-devel-tpls
   ubuntu_18_04_cuda_11_4_0_tag: alpinedav/ascent-ci:ubuntu-18.04-cuda-11.4.0-devel-tpls_2022-07-13-sha3ef3e7
 
 

--- a/scripts/uberenv_configs/packages/ascent/package.py
+++ b/scripts/uberenv_configs/packages/ascent/package.py
@@ -147,7 +147,7 @@ class Ascent(CMakePackage, CudaPackage):
     
     # ascent newer than 0.8.0 uses internal vtk-h
     # use vtk-m 1.8 for newer than ascent 0.8.0
-    depends_on("vtk-m@:1.8", when="@0.8.1:")
+    depends_on("vtk-m@1.8:", when="@0.8.1:")
 
     depends_on("vtk-m~tbb", when="@0.8.1: +vtkh")
     depends_on("vtk-m+openmp", when="@0.8.1: +vtkh+openmp")

--- a/scripts/uberenv_configs/packages/vtk-m/package.py
+++ b/scripts/uberenv_configs/packages/vtk-m/package.py
@@ -29,7 +29,6 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     version('master', branch='master')
     version('release', branch='release')
     version('1.8.0', sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768")
-    version('1.8.0-rc1', sha256="99e344c89ecb84b04cc0f0b9fdf042b9a4ae3144bb4deeca8e90f098ab8a569b")
     version('1.7.1', sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63", preferred=True)
     version('1.7.0', sha256="a86667ac22057462fc14495363cfdcc486da125b366cb568ec23c86946439be4")
     version('1.6.0', sha256="14e62d306dd33f82eb9ddb1d5cee987b7a0b91bf08a7a02ca3bce3968c95fd76")

--- a/src/cmake/Setup3rdParty.cmake
+++ b/src/cmake/Setup3rdParty.cmake
@@ -39,6 +39,13 @@ include(cmake/thirdparty/SetupConduit.cmake)
 ################################################################
 
 ################################
+# Camp
+################################
+if(CAMP_DIR) # optional for now
+    include(cmake/thirdparty/SetupCamp.cmake)
+endif()
+
+################################
 # Umpire
 ################################
 if(UMPIRE_DIR) # optional for now

--- a/src/cmake/thirdparty/SetupCamp.cmake
+++ b/src/cmake/thirdparty/SetupCamp.cmake
@@ -1,0 +1,26 @@
+# Copyright (c) Lawrence Livermore National Security, LLC and other Ascent
+# Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Ascent.
+
+if(NOT CAMP_DIR)
+  message(FATAL_ERROR "Camp support needs explicit CAMP_DIR")
+endif()
+
+message(STATUS "Looking for Camp in: ${CAMP_DIR}")
+
+set(_CAMP_SEARCH_PATH)
+if(EXISTS  ${CAMP_DIR}/share/camp/cmake)
+  # old install layout ?
+  set(_CAMP_SEARCH_PATH ${CAMP_DIR}/share/camp/cmake)
+else()
+  # new install layout ?
+  set(_CAMP_SEARCH_PATH ${CAMP_DIR}/lib/cmake/camp)
+endif()
+
+set(_CAMP_SEARCH_PATH ${CAMP_DIR})
+find_package(camp REQUIRED
+             NO_DEFAULT_PATH
+             PATHS ${_CAMP_SEARCH_PATH})
+             
+message(STATUS "Found Camp in: ${CAMP_DIR}")
+set(CAMP_FOUND TRUE)

--- a/src/cmake/thirdparty/SetupRAJA.cmake
+++ b/src/cmake/thirdparty/SetupRAJA.cmake
@@ -2,14 +2,24 @@
 # Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
 # other details. No copyright assignment is required to contribute to Ascent.
 
+if(NOT RAJA_DIR)
+  message(FATAL_ERROR "RAJA support needs explicit RAJA_DIR")
+endif()
+
 message(STATUS "Looking for RAJA in: ${RAJA_DIR}")
-if (NOT RAJA_DIR)
-  message(FATAL_ERROR "Must specify 'RAJA_DIR'")
+
+set(_RAJA_SEARCH_PATH)
+if(EXISTS ${RAJA_DIR}/share/raja/cmake)
+  # old install layout
+  set(_RAJA_SEARCH_PATH ${RAJA_DIR}/share/raja/cmake)
+else()
+  # new install layout
+  set(_RAJA_SEARCH_PATH ${RAJA_DIR}/lib/cmake/raja)
 endif()
 
 set(RAJA_DIR_ORIG ${RAJA_DIR})
 find_dependency(RAJA REQUIRED
                 NO_DEFAULT_PATH
-                PATHS ${RAJA_DIR}/share/raja/cmake)
+                PATHS ${_RAJA_SEARCH_PATH})
 
-message(STATUS "Found RAJA")
+message(STATUS "Found RAJA in: ${RAJA_DIR}")

--- a/src/cmake/thirdparty/SetupUmpire.cmake
+++ b/src/cmake/thirdparty/SetupUmpire.cmake
@@ -9,11 +9,11 @@ endif()
 message(STATUS "Looking for Umpire in: ${UMPIRE_DIR}")
 
 set(_UMPIRE_SEARCH_PATH)
-if(EXISTS  ${UMPIRE_DIR}/share/umpire/cmake)
-  # old umpire install layout
+if(EXISTS ${UMPIRE_DIR}/share/umpire/cmake)
+  # old install layout
   set(_UMPIRE_SEARCH_PATH ${UMPIRE_DIR}/share/umpire/cmake)
 else()
-  # new umpire install layout
+  # new install layout
   set(_UMPIRE_SEARCH_PATH ${UMPIRE_DIR}/lib/cmake/umpire)
 endif()
 
@@ -21,6 +21,6 @@ set(UMPIRE_DIR_ORIG ${UMPIRE_DIR})
 find_package(umpire REQUIRED
              NO_DEFAULT_PATH
              PATHS ${_UMPIRE_SEARCH_PATH})
-             
+
 message(STATUS "Found Umpire in: ${UMPIRE_DIR}")
 set(UMPIRE_FOUND TRUE)


### PR DESCRIPTION
fix macos spack config
update version constraints to select vtk-m 1.8.0 automatically for newer ascent builds
allow newer raja and umpire to be used