### PR TITLE
support for oneapi ifx compiler

### DIFF
--- a/src/examples/proxies/cloverleaf3d-ref/CMakeLists.txt
+++ b/src/examples/proxies/cloverleaf3d-ref/CMakeLists.txt
@@ -88,6 +88,7 @@ if(MPI_FOUND AND FORTRAN_FOUND)
     blt_append_custom_compiler_flag(
             FLAGS_VAR clover_link_flags
             INTEL   "-nofor_main"
+            INTELLLVM   "-nofor-main"
         )
 
     # these flags are needeed for gfortran 10 to avoid


### PR DESCRIPTION
-nofor_main has been deprecated for ifort, but still works
Use -nofor-main for ifx