### PR TITLE
Add oneapi compilers to CI

### DIFF
--- a/.github/workflows/build_ascent.yml
+++ b/.github/workflows/build_ascent.yml
@@ -6,8 +6,21 @@ on:
 
 jobs:
   build_pip_basic:
-    name: Ubuntu Build Ascent
+    strategy:
+      matrix:
+        include:
+        - cc: gcc
+          cxx: g++
+          fc: gfortran
+        - cc: icx
+          cxx: icpx
+          fc: ifx
+    name: Ubuntu Build Ascent (${{ matrix.cc }})
     runs-on: ubuntu-latest
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+      FC: ${{ matrix.fc }}
     steps:
     - name: Install System Deps
       run: |
@@ -37,12 +50,23 @@ jobs:
                                 mpich \
                                 libmpich-dev \
                                 cmake
+    - name: Install intel compilers
+      if: ${{ matrix.cc == 'icx' || matrix.cc == 'icc' }}
+      run: |
+        curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+          | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+          sudo tee /etc/apt/sources.list.d/oneAPI.list > /dev/null
+        sudo apt-get update
+        sudo apt install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
+                       intel-oneapi-compiler-fortran
     - name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'recursive'
     - name: Build TPLs
       run: |
+        source /opt/intel/oneapi/setvars.sh || true
         env enable_mpi=ON \
             enable_fortran=ON \
             enable_tests=OFF \
@@ -53,10 +77,12 @@ jobs:
     - name: Build Ascent
       run: |
         echo "**** Configuring Ascent"
+        source /opt/intel/oneapi/setvars.sh || true
         cmake -S src -B build -C ascent-config.cmake
     - name: Build Ascent
       run: |
         echo "**** Building Ascent"
+        source /opt/intel/oneapi/setvars.sh || true
         cmake --build  build -j2
     - name: Install Ascent
       run: |

--- a/src/cmake/CMakeBasics.cmake
+++ b/src/cmake/CMakeBasics.cmake
@@ -43,8 +43,9 @@ macro(ENABLE_WARNINGS)
     else()
         if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
             "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU"   OR
-            "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
-            # use these flags for clang, gcc, or icc
+            "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" OR
+            "${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM")
+            # use these flags for clang, gcc, icc, or icx
             add_definitions(-Wall -Wextra)
         endif()
     endif()

--- a/src/examples/proxies/cloverleaf3d-ref/CMakeLists.txt
+++ b/src/examples/proxies/cloverleaf3d-ref/CMakeLists.txt
@@ -88,6 +88,7 @@ if(MPI_FOUND AND FORTRAN_FOUND)
     blt_append_custom_compiler_flag(
             FLAGS_VAR clover_link_flags
             INTEL   "-nofor_main"
+            INTELLLVM   "-nofor-main"
         )
 
     # these flags are needeed for gfortran 10 to avoid


### PR DESCRIPTION
Adds oneapi compilers to CI and updates build scripts for oneapi compilers. Builds  ascent and tpl with icx/icpx/ifx.

I tried building tpl with gcc and ascent with oneapi but ifx cannot use modules built with gfortran. I also tried adding icc/icpc/ifort, but the build is very slow. It did not finish after 2 hours.

It passes in my fork.