### PR TITLE
initialize kokkos in vtkh tests

### DIFF
--- a/src/libs/vtkh/vtkh.cpp
+++ b/src/libs/vtkh/vtkh.cpp
@@ -310,7 +310,13 @@ SelectCUDADevice(int device_index)
 
 }
 //---------------------------------------------------------------------------//
+void
+InitializeKokkos()
+{
+  SelectKokkosDevice(0);
+}
 
+//---------------------------------------------------------------------------//
 void
 SelectKokkosDevice(int device_index)
 { 

--- a/src/libs/vtkh/vtkh.hpp
+++ b/src/libs/vtkh/vtkh.hpp
@@ -27,6 +27,7 @@ namespace vtkh
 
   VTKH_API int         CUDADeviceCount();
   VTKH_API void        SelectCUDADevice(int device_index);
+  VTKH_API void        InitializeKokkos();
   VTKH_API void        SelectKokkosDevice(int device_index);
 
   VTKH_API void        ForceSerial();

--- a/src/tests/ascent/t_ascent_vtkh_data_adapter.cpp
+++ b/src/tests/ascent/t_ascent_vtkh_data_adapter.cpp
@@ -83,6 +83,9 @@ TEST(ascent_data_adapter, vtkm_uniform_3d_to_blueprint)
 //-----------------------------------------------------------------------------
 TEST(ascent_data_adapter, vtkm_rectilinear_3d_to_blueprint)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+    vtkh::InitializeKokkos();
+#endif
     Node n;
     ascent::about(n);
     // only run this test if ascent was built with vtkm support

--- a/src/tests/vtkh/t_vtk-h_clip.cpp
+++ b/src/tests/vtkh/t_vtk-h_clip.cpp
@@ -22,6 +22,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_clip, vtkh_box_clip)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -79,6 +82,9 @@ TEST(vtkh_clip, vtkh_box_clip)
 
 TEST(vtkh_clip, vtkh_2_plane_clip)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -139,6 +145,9 @@ TEST(vtkh_clip, vtkh_2_plane_clip)
 
 TEST(vtkh_clip, vtkh_2_plane_clip_particles)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int size = 1000;

--- a/src/tests/vtkh/t_vtk-h_clip.cpp
+++ b/src/tests/vtkh/t_vtk-h_clip.cpp
@@ -23,7 +23,7 @@
 TEST(vtkh_clip, vtkh_box_clip)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -83,7 +83,7 @@ TEST(vtkh_clip, vtkh_box_clip)
 TEST(vtkh_clip, vtkh_2_plane_clip)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -146,7 +146,7 @@ TEST(vtkh_clip, vtkh_2_plane_clip)
 TEST(vtkh_clip, vtkh_2_plane_clip_particles)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_clip_field.cpp
+++ b/src/tests/vtkh/t_vtk-h_clip_field.cpp
@@ -23,7 +23,7 @@
 TEST(vtkh_clip_field, vtkh_clip)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -74,7 +74,7 @@ TEST(vtkh_clip_field, vtkh_clip)
 TEST(vtkh_clip_field, vtkh_clip_cell_centered)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_clip_field.cpp
+++ b/src/tests/vtkh/t_vtk-h_clip_field.cpp
@@ -22,6 +22,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_clip_field, vtkh_clip)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -70,6 +73,9 @@ TEST(vtkh_clip_field, vtkh_clip)
 //----------------------------------------------------------------------------
 TEST(vtkh_clip_field, vtkh_clip_cell_centered)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_dataset.cpp
+++ b/src/tests/vtkh/t_vtk-h_dataset.cpp
@@ -18,7 +18,7 @@
 TEST(vtkh_dataset, vtkh_range)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_dataset.cpp
+++ b/src/tests/vtkh/t_vtk-h_dataset.cpp
@@ -17,6 +17,9 @@
 //-----------------------------------------------------------------------------
 TEST(vtkh_dataset, vtkh_range)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_dataset_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_dataset_par.cpp
@@ -18,6 +18,9 @@
 //-----------------------------------------------------------------------------
 TEST(vtkh_dataset_par, vtkh_range_par)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_dataset_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_dataset_par.cpp
@@ -19,7 +19,7 @@
 TEST(vtkh_dataset_par, vtkh_range_par)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_empty_data.cpp
+++ b/src/tests/vtkh/t_vtk-h_empty_data.cpp
@@ -24,6 +24,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_emtpy_data, vtkh_empty_vtkm)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -121,6 +124,9 @@ TEST(vtkh_emtpy_data, vtkh_empty_vtkm)
 //----------------------------------------------------------------------------
 TEST(vtkh_emtpy_data, vtkh_empty_vtkh)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   vtkh::IsoVolume iso;

--- a/src/tests/vtkh/t_vtk-h_empty_data.cpp
+++ b/src/tests/vtkh/t_vtk-h_empty_data.cpp
@@ -25,7 +25,7 @@
 TEST(vtkh_emtpy_data, vtkh_empty_vtkm)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -125,7 +125,7 @@ TEST(vtkh_emtpy_data, vtkh_empty_vtkm)
 TEST(vtkh_emtpy_data, vtkh_empty_vtkh)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_ghost_stripper.cpp
+++ b/src/tests/vtkh/t_vtk-h_ghost_stripper.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_ghost_stripper, vtkh_ghost_stripper)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -78,7 +78,7 @@ TEST(vtkh_ghost_stripper, vtkh_ghost_stripper)
 TEST(vtkh_ghost_stripper, vtkh_ghost_stripper_no_strip)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_ghost_stripper.cpp
+++ b/src/tests/vtkh/t_vtk-h_ghost_stripper.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_ghost_stripper, vtkh_ghost_stripper)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -74,6 +77,9 @@ TEST(vtkh_ghost_stripper, vtkh_ghost_stripper)
 //----------------------------------------------------------------------------
 TEST(vtkh_ghost_stripper, vtkh_ghost_stripper_no_strip)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_gradient.cpp
+++ b/src/tests/vtkh/t_vtk-h_gradient.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_gradient, vtkh_gradient)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -86,7 +86,7 @@ TEST(vtkh_gradient, vtkh_gradient)
 TEST(vtkh_gradient, vtkh_qcriterion)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_gradient.cpp
+++ b/src/tests/vtkh/t_vtk-h_gradient.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_gradient, vtkh_gradient)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -82,6 +85,9 @@ TEST(vtkh_gradient, vtkh_gradient)
 //----------------------------------------------------------------------------
 TEST(vtkh_gradient, vtkh_qcriterion)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_histogram_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_histogram_par.cpp
@@ -17,6 +17,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_histogram_par, vtkh_histogram_clamp_range)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_histogram_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_histogram_par.cpp
@@ -18,7 +18,7 @@
 TEST(vtkh_histogram_par, vtkh_histogram_clamp_range)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   MPI_Init(NULL, NULL);

--- a/src/tests/vtkh/t_vtk-h_iso_volume.cpp
+++ b/src/tests/vtkh/t_vtk-h_iso_volume.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_iso_volume, vtkh_iso_volume)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -76,7 +76,7 @@ TEST(vtkh_iso_volume, vtkh_iso_volume)
 TEST(vtkh_iso_volume, vtkh_iso_volume_empty)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_iso_volume.cpp
+++ b/src/tests/vtkh/t_vtk-h_iso_volume.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_iso_volume, vtkh_iso_volume)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -72,6 +75,9 @@ TEST(vtkh_iso_volume, vtkh_iso_volume)
 //----------------------------------------------------------------------------
 TEST(vtkh_iso_volume, vtkh_iso_volume_empty)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_lagrangian.cpp
+++ b/src/tests/vtkh/t_vtk-h_lagrangian.cpp
@@ -94,7 +94,7 @@ void render_output(vtkh::DataSet *data, std::string file_name)
 TEST(vtkh_lagrangian, vtkh_serial_lagrangian)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::Lagrangian lagrangian;
   lagrangian.SetField("velocity");

--- a/src/tests/vtkh/t_vtk-h_lagrangian.cpp
+++ b/src/tests/vtkh/t_vtk-h_lagrangian.cpp
@@ -93,6 +93,9 @@ void render_output(vtkh::DataSet *data, std::string file_name)
 //----------------------------------------------------------------------------
 TEST(vtkh_lagrangian, vtkh_serial_lagrangian)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::Lagrangian lagrangian;
   lagrangian.SetField("velocity");
   lagrangian.SetStepSize(0.1);

--- a/src/tests/vtkh/t_vtk-h_log.cpp
+++ b/src/tests/vtkh/t_vtk-h_log.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_log, vtkh_log)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_log.cpp
+++ b/src/tests/vtkh/t_vtk-h_log.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_log, vtkh_log)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_marching_cubes.cpp
+++ b/src/tests/vtkh/t_vtk-h_marching_cubes.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_marching_cubes, vtkh_serial_marching_cubes)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -70,6 +73,9 @@ TEST(vtkh_marching_cubes, vtkh_serial_marching_cubes)
 //----------------------------------------------------------------------------
 TEST(vtkh_marching_cubes, vtkh_empty)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -120,6 +126,9 @@ TEST(vtkh_marching_cubes, vtkh_empty)
 //----------------------------------------------------------------------------
 TEST(vtkh_marching_cubes, vtkh_marching_cubes_recenter)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_marching_cubes.cpp
+++ b/src/tests/vtkh/t_vtk-h_marching_cubes.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_marching_cubes, vtkh_serial_marching_cubes)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -74,7 +74,7 @@ TEST(vtkh_marching_cubes, vtkh_serial_marching_cubes)
 TEST(vtkh_marching_cubes, vtkh_empty)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_marching_cubes_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_marching_cubes_par.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_marching_cubes_par, vtkh_parallel_marching_cubes)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_marching_cubes_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_marching_cubes_par.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_marching_cubes_par, vtkh_parallel_marching_cubes)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   MPI_Init(NULL, NULL);

--- a/src/tests/vtkh/t_vtk-h_mesh_quality.cpp
+++ b/src/tests/vtkh/t_vtk-h_mesh_quality.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_mesh_quality, vtkh_volume)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -65,7 +65,7 @@ TEST(vtkh_mesh_quality, vtkh_volume)
 TEST(vtkh_mesh_quality, vtkh_not_supported)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_mesh_quality.cpp
+++ b/src/tests/vtkh/t_vtk-h_mesh_quality.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_mesh_quality, vtkh_volume)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -61,6 +64,9 @@ TEST(vtkh_mesh_quality, vtkh_volume)
 //----------------------------------------------------------------------------
 TEST(vtkh_mesh_quality, vtkh_not_supported)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_mesh_renderer.cpp
+++ b/src/tests/vtkh/t_vtk-h_mesh_renderer.cpp
@@ -19,6 +19,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_mesh_renderer, vtkh_serial_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 16;
@@ -54,6 +57,9 @@ TEST(vtkh_mesh_renderer, vtkh_serial_render)
 //----------------------------------------------------------------------------
 TEST(vtkh_mesh_renderer, vtkh_serial_render_no_field)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 16;

--- a/src/tests/vtkh/t_vtk-h_mesh_renderer.cpp
+++ b/src/tests/vtkh/t_vtk-h_mesh_renderer.cpp
@@ -20,7 +20,7 @@
 TEST(vtkh_mesh_renderer, vtkh_serial_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -58,7 +58,7 @@ TEST(vtkh_mesh_renderer, vtkh_serial_render)
 TEST(vtkh_mesh_renderer, vtkh_serial_render_no_field)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_multi_render.cpp
+++ b/src/tests/vtkh/t_vtk-h_multi_render.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_raytracer, vtkh_serial_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -82,6 +85,9 @@ TEST(vtkh_raytracer, vtkh_serial_render)
 //----------------------------------------------------------------------------
 TEST(vtkh_raytracer, vtkh_serial_batch)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_multi_render.cpp
+++ b/src/tests/vtkh/t_vtk-h_multi_render.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_raytracer, vtkh_serial_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -86,7 +86,7 @@ TEST(vtkh_raytracer, vtkh_serial_render)
 TEST(vtkh_raytracer, vtkh_serial_batch)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_multi_render_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_multi_render_par.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_raytracer, vtkh_serial_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -88,6 +91,9 @@ TEST(vtkh_raytracer, vtkh_serial_render)
 //----------------------------------------------------------------------------
 TEST(vtkh_multi_par, vtkh_batch)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/src/tests/vtkh/t_vtk-h_multi_render_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_multi_render_par.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_raytracer, vtkh_serial_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -92,7 +92,7 @@ TEST(vtkh_raytracer, vtkh_serial_render)
 TEST(vtkh_multi_par, vtkh_batch)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_no_op.cpp
+++ b/src/tests/vtkh/t_vtk-h_no_op.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_no_op, vtkh_serial_no_op)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_no_op.cpp
+++ b/src/tests/vtkh/t_vtk-h_no_op.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_no_op, vtkh_serial_no_op)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_no_op_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_no_op_par.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_no_op_par, vtkh_parallel_no_op)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   MPI_Init(NULL, NULL);

--- a/src/tests/vtkh/t_vtk-h_no_op_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_no_op_par.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_no_op_par, vtkh_parallel_no_op)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_particle_advection_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_particle_advection_par.cpp
@@ -93,7 +93,7 @@ RunFilter(vtkh::DataSet& input,
 TEST(vtkh_particle_advection, vtkh_serial_particle_advection)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_particle_advection_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_particle_advection_par.cpp
@@ -92,6 +92,9 @@ RunFilter(vtkh::DataSet& input,
 //----------------------------------------------------------------------------
 TEST(vtkh_particle_advection, vtkh_serial_particle_advection)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_point_renderer.cpp
+++ b/src/tests/vtkh/t_vtk-h_point_renderer.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_point_renderer, vtkh_point_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 16;
@@ -55,6 +58,9 @@ TEST(vtkh_point_renderer, vtkh_point_render)
 
 TEST(vtkh_point_renderer, vtkh_variable_point_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 16;
@@ -92,6 +98,9 @@ TEST(vtkh_point_renderer, vtkh_variable_point_render)
 
 TEST(vtkh_point_renderer, vtkh_point_no_data)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 16;

--- a/src/tests/vtkh/t_vtk-h_point_renderer.cpp
+++ b/src/tests/vtkh/t_vtk-h_point_renderer.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_point_renderer, vtkh_point_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -59,7 +59,7 @@ TEST(vtkh_point_renderer, vtkh_point_render)
 TEST(vtkh_point_renderer, vtkh_variable_point_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -99,7 +99,7 @@ TEST(vtkh_point_renderer, vtkh_variable_point_render)
 TEST(vtkh_point_renderer, vtkh_point_no_data)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_point_transform.cpp
+++ b/src/tests/vtkh/t_vtk-h_point_transform.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_point_transform, vtkh_translate)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -60,6 +63,9 @@ TEST(vtkh_point_transform, vtkh_translate)
 
 TEST(vtkh_point_transform, vtkh_scale)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_point_transform.cpp
+++ b/src/tests/vtkh/t_vtk-h_point_transform.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_point_transform, vtkh_translate)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -64,7 +64,7 @@ TEST(vtkh_point_transform, vtkh_translate)
 TEST(vtkh_point_transform, vtkh_scale)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_raytracer.cpp
+++ b/src/tests/vtkh/t_vtk-h_raytracer.cpp
@@ -20,7 +20,7 @@
 TEST(vtkh_raytracer, vtkh_serial_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_raytracer.cpp
+++ b/src/tests/vtkh/t_vtk-h_raytracer.cpp
@@ -19,6 +19,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_raytracer, vtkh_serial_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_raytracer_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_raytracer_par.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_raytracer, vtkh_parallel_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_raytracer_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_raytracer_par.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_raytracer, vtkh_parallel_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_render.cpp
+++ b/src/tests/vtkh/t_vtk-h_render.cpp
@@ -19,6 +19,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_render, vtkh_scaled_world_annotations)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -56,6 +59,9 @@ TEST(vtkh_render, vtkh_scaled_world_annotations)
 //----------------------------------------------------------------------------
 TEST(vtkh_render, vtkh_no_annotations)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -90,6 +96,9 @@ TEST(vtkh_render, vtkh_no_annotations)
 
 TEST(vtkh_render, vtkh_no_bg_or_annotations)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -125,6 +134,9 @@ TEST(vtkh_render, vtkh_no_bg_or_annotations)
 
 TEST(vtkh_render, vtkh_no_world_annotations)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -159,6 +171,9 @@ TEST(vtkh_render, vtkh_no_world_annotations)
 
 TEST(vtkh_render, vtkh_no_screen_annotations)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -193,6 +208,9 @@ TEST(vtkh_render, vtkh_no_screen_annotations)
 
 TEST(vtkh_render, vtkh_bg_color)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_render.cpp
+++ b/src/tests/vtkh/t_vtk-h_render.cpp
@@ -20,7 +20,7 @@
 TEST(vtkh_render, vtkh_scaled_world_annotations)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -60,7 +60,7 @@ TEST(vtkh_render, vtkh_scaled_world_annotations)
 TEST(vtkh_render, vtkh_no_annotations)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -97,7 +97,7 @@ TEST(vtkh_render, vtkh_no_annotations)
 TEST(vtkh_render, vtkh_no_bg_or_annotations)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -135,7 +135,7 @@ TEST(vtkh_render, vtkh_no_bg_or_annotations)
 TEST(vtkh_render, vtkh_no_world_annotations)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -172,7 +172,7 @@ TEST(vtkh_render, vtkh_no_world_annotations)
 TEST(vtkh_render, vtkh_no_screen_annotations)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -209,7 +209,7 @@ TEST(vtkh_render, vtkh_no_screen_annotations)
 TEST(vtkh_render, vtkh_bg_color)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_sampling_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_sampling_par.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_hist_sampling_par, vtkh_sampling_point_view)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   int comm_size, rank;
@@ -78,7 +78,7 @@ TEST(vtkh_hist_sampling_par, vtkh_sampling_point_view)
 TEST(vtkh_hist_sampling_par, vtkh_sampling_cell_view)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_sampling_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_sampling_par.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_hist_sampling_par, vtkh_sampling_point_view)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -74,6 +77,9 @@ TEST(vtkh_hist_sampling_par, vtkh_sampling_point_view)
 //----------------------------------------------------------------------------
 TEST(vtkh_hist_sampling_par, vtkh_sampling_cell_view)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_scalar_renderer_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_scalar_renderer_par.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_scalar_renderer, vtkh_parallel_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_scalar_renderer_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_scalar_renderer_par.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_scalar_renderer, vtkh_parallel_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   MPI_Init(NULL, NULL);
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_slice.cpp
+++ b/src/tests/vtkh/t_vtk-h_slice.cpp
@@ -18,7 +18,7 @@
 TEST(vtkh_slice, vtkh_slice)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -64,7 +64,7 @@ TEST(vtkh_slice, vtkh_slice)
 TEST(vtkh_slice, vtkh_mulit_slice)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_slice.cpp
+++ b/src/tests/vtkh/t_vtk-h_slice.cpp
@@ -17,6 +17,9 @@
 
 TEST(vtkh_slice, vtkh_slice)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -60,6 +63,9 @@ TEST(vtkh_slice, vtkh_slice)
 
 TEST(vtkh_slice, vtkh_mulit_slice)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_statistics_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_statistics_par.cpp
@@ -17,6 +17,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_statistics_par, vtkh_stats)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   MPI_Init(NULL, NULL);
   int comm_size, rank;

--- a/src/tests/vtkh/t_vtk-h_statistics_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_statistics_par.cpp
@@ -18,7 +18,7 @@
 TEST(vtkh_statistics_par, vtkh_stats)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   MPI_Init(NULL, NULL);

--- a/src/tests/vtkh/t_vtk-h_threshold.cpp
+++ b/src/tests/vtkh/t_vtk-h_threshold.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_threshold, vtkh_serial_threshold)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_threshold.cpp
+++ b/src/tests/vtkh/t_vtk-h_threshold.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_threshold, vtkh_serial_threshold)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_vector_ops.cpp
+++ b/src/tests/vtkh/t_vtk-h_vector_ops.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_vector_ops, vtkh_vector_magnitude)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -67,6 +70,9 @@ TEST(vtkh_vector_ops, vtkh_vector_magnitude)
 //----------------------------------------------------------------------------
 TEST(vtkh_vector_ops, vtkh_composite_vector)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;
@@ -119,6 +125,9 @@ TEST(vtkh_vector_ops, vtkh_composite_vector)
 //----------------------------------------------------------------------------
 TEST(vtkh_vector_ops, vtkh_vector_component)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   vtkh::DataSet data_set;
 
   const int base_size = 32;

--- a/src/tests/vtkh/t_vtk-h_vector_ops.cpp
+++ b/src/tests/vtkh/t_vtk-h_vector_ops.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_vector_ops, vtkh_vector_magnitude)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -71,7 +71,7 @@ TEST(vtkh_vector_ops, vtkh_vector_magnitude)
 TEST(vtkh_vector_ops, vtkh_composite_vector)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 
@@ -126,7 +126,7 @@ TEST(vtkh_vector_ops, vtkh_composite_vector)
 TEST(vtkh_vector_ops, vtkh_vector_component)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_volume_renderer.cpp
+++ b/src/tests/vtkh/t_vtk-h_volume_renderer.cpp
@@ -21,7 +21,7 @@
 TEST(vtkh_volume_renderer, vtkh_parallel_render_ustructured)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
 
   vtkh::DataSet data_set;

--- a/src/tests/vtkh/t_vtk-h_volume_renderer.cpp
+++ b/src/tests/vtkh/t_vtk-h_volume_renderer.cpp
@@ -20,6 +20,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_volume_renderer, vtkh_parallel_render_ustructured)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   vtkh::DataSet data_set;
 
@@ -75,6 +78,9 @@ TEST(vtkh_volume_renderer, vtkh_parallel_render_ustructured)
 
 TEST(vtkh_volume_renderer, vtkh_parallel_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
 
   vtkh::DataSet data_set;
 

--- a/src/tests/vtkh/t_vtk-h_volume_renderer_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_volume_renderer_par.cpp
@@ -22,7 +22,7 @@
 TEST(vtkh_volume_renderer, vtkh_parallel_render)
 {
 #ifdef VTKM_ENABLE_KOKKOS
-  vtkh::SelectKokkosDevice(1);
+  vtkh::InitializeKokkos();
 #endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);

--- a/src/tests/vtkh/t_vtk-h_volume_renderer_par.cpp
+++ b/src/tests/vtkh/t_vtk-h_volume_renderer_par.cpp
@@ -21,6 +21,9 @@
 //----------------------------------------------------------------------------
 TEST(vtkh_volume_renderer, vtkh_parallel_render)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -68,6 +71,9 @@ TEST(vtkh_volume_renderer, vtkh_parallel_render)
 //----------------------------------------------------------------------------
 TEST(vtkh_volume_renderer, vtkh_parallel_render_unstructured_blank)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -135,6 +141,9 @@ TEST(vtkh_volume_renderer, vtkh_parallel_render_unstructured_blank)
 //-----------------------------------------------------------------------------
 TEST(vtkh_volume_renderer, vtkh_parallel_render_unstructured)
 {
+#ifdef VTKM_ENABLE_KOKKOS
+  vtkh::SelectKokkosDevice(1);
+#endif
   int comm_size, rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);


### PR DESCRIPTION
Kokkos needs to be initialized and VTKm does not do it. 