### PR TITLE
Optional symbol visibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ option(ENABLE_UTILS       "Build Utilities"           ON)
 option(ENABLE_LOGGING     "Enable data logging"       OFF)
 option(ENABLE_DOCS        "Build Documentation"       ON)
 
+option(ENABLE_HIDDEN_VISIBILITY "Build with hidden visibility for private symbols" ON)
+
 # DRay Specific Options
 option(DRAY_ENABLE_STATS          "Enable stats"         ON)
 option(DRAY_USE_DOUBLE_PRECISION  "Build Devil Ray with double precision" OFF)

--- a/src/ascent/CMakeLists.txt
+++ b/src/ascent/CMakeLists.txt
@@ -352,7 +352,9 @@ if (ENABLE_SERIAL)
                     HEADERS     ${ascent_headers}
                     DEPENDS_ON  ${ascent_thirdparty_libs})
 
-#    set_target_properties(ascent PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(ascent PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     target_compile_definitions(ascent PRIVATE ASCENT_EXPORTS_FLAG)
 
     # TODO move to header ...
@@ -522,7 +524,9 @@ if(MPI_FOUND)
         HEADERS     ${ascent_headers} ${ascent_mpi_headers}
         DEPENDS_ON  ${ascent_mpi_thirdparty_libs})
 
-#    set_target_properties(ascent_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(ascent_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     target_compile_definitions(ascent_mpi PRIVATE ASCENT_EXPORTS_FLAG)
 
     if(ENABLE_LOGGING)

--- a/src/ascent/CMakeLists.txt
+++ b/src/ascent/CMakeLists.txt
@@ -352,7 +352,7 @@ if (ENABLE_SERIAL)
                     HEADERS     ${ascent_headers}
                     DEPENDS_ON  ${ascent_thirdparty_libs})
 
-    set_target_properties(ascent PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(ascent PROPERTIES CXX_VISIBILITY_PRESET hidden)
     target_compile_definitions(ascent PRIVATE ASCENT_EXPORTS_FLAG)
 
     # TODO move to header ...
@@ -522,7 +522,7 @@ if(MPI_FOUND)
         HEADERS     ${ascent_headers} ${ascent_mpi_headers}
         DEPENDS_ON  ${ascent_mpi_thirdparty_libs})
 
-    set_target_properties(ascent_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(ascent_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
     target_compile_definitions(ascent_mpi PRIVATE ASCENT_EXPORTS_FLAG)
 
     if(ENABLE_LOGGING)

--- a/src/flow/CMakeLists.txt
+++ b/src/flow/CMakeLists.txt
@@ -74,7 +74,7 @@ blt_add_library(
     HEADERS     ${flow_headers}
     DEPENDS_ON  ${flow_thirdparty_libs})
 
-set_target_properties(ascent_flow PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# set_target_properties(ascent_flow PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(ascent_flow PRIVATE ASCENT_EXPORTS_FLAG)
     
 # install target for serial ascent lib

--- a/src/flow/CMakeLists.txt
+++ b/src/flow/CMakeLists.txt
@@ -74,7 +74,9 @@ blt_add_library(
     HEADERS     ${flow_headers}
     DEPENDS_ON  ${flow_thirdparty_libs})
 
-# set_target_properties(ascent_flow PROPERTIES CXX_VISIBILITY_PRESET hidden)
+if(ENABLE_HIDDEN_VISIBILITY)
+  set_target_properties(ascent_flow PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
 target_compile_definitions(ascent_flow PRIVATE ASCENT_EXPORTS_FLAG)
     
 # install target for serial ascent lib

--- a/src/libs/vtkh/CMakeLists.txt
+++ b/src/libs/vtkh/CMakeLists.txt
@@ -92,7 +92,7 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_core PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_core PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_core PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
     # build includes
     # this allows us to include as <vtkh/header.hpp>
@@ -128,7 +128,7 @@ if(MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_core_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_core_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_core_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
     #
     target_compile_definitions(vtkh_core_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/CMakeLists.txt
+++ b/src/libs/vtkh/CMakeLists.txt
@@ -92,7 +92,9 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_core PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_core PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_core PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
 
     # build includes
     # this allows us to include as <vtkh/header.hpp>

--- a/src/libs/vtkh/CMakeLists.txt
+++ b/src/libs/vtkh/CMakeLists.txt
@@ -130,7 +130,9 @@ if(MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_core_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_core_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_core_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     #
     target_compile_definitions(vtkh_core_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/compositing/CMakeLists.txt
+++ b/src/libs/vtkh/compositing/CMakeLists.txt
@@ -40,7 +40,9 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_compositing PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_compositing PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_compositing PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
 
     # build includes
     # this allows us to include as <vtkh/header.hpp>

--- a/src/libs/vtkh/compositing/CMakeLists.txt
+++ b/src/libs/vtkh/compositing/CMakeLists.txt
@@ -40,7 +40,7 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_compositing PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_compositing PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_compositing PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
     # build includes
     # this allows us to include as <vtkh/header.hpp>
@@ -98,7 +98,7 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_compositing_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_compositing_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_compositing_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
     #
     target_compile_definitions(vtkh_compositing_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/compositing/CMakeLists.txt
+++ b/src/libs/vtkh/compositing/CMakeLists.txt
@@ -100,7 +100,9 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_compositing_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_compositing_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_compositing_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     #
     target_compile_definitions(vtkh_compositing_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/filters/CMakeLists.txt
+++ b/src/libs/vtkh/filters/CMakeLists.txt
@@ -100,7 +100,7 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_filters PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
     if(CUDA_FOUND)
         set_target_properties(vtkh_filters PROPERTIES LINKER_LANGUAGE CUDA)
@@ -141,7 +141,7 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_filters_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_filters_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_filters_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
     #
     target_compile_definitions(vtkh_filters_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/filters/CMakeLists.txt
+++ b/src/libs/vtkh/filters/CMakeLists.txt
@@ -100,7 +100,9 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_filters PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
 
     if(CUDA_FOUND)
         set_target_properties(vtkh_filters PROPERTIES LINKER_LANGUAGE CUDA)

--- a/src/libs/vtkh/filters/CMakeLists.txt
+++ b/src/libs/vtkh/filters/CMakeLists.txt
@@ -143,7 +143,9 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_filters_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_filters_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_filters_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     #
     target_compile_definitions(vtkh_filters_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/rendering/CMakeLists.txt
+++ b/src/libs/vtkh/rendering/CMakeLists.txt
@@ -46,7 +46,9 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_rendering PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_rendering PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_rendering PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
 
     # Install libraries
     install(TARGETS vtkh_rendering

--- a/src/libs/vtkh/rendering/CMakeLists.txt
+++ b/src/libs/vtkh/rendering/CMakeLists.txt
@@ -46,7 +46,7 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_rendering PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_rendering PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_rendering PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
     # Install libraries
     install(TARGETS vtkh_rendering
@@ -73,7 +73,7 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_rendering_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_rendering_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_rendering_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
     #
     target_compile_definitions(vtkh_rendering_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/rendering/CMakeLists.txt
+++ b/src/libs/vtkh/rendering/CMakeLists.txt
@@ -75,7 +75,9 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_rendering_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_rendering_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_rendering_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     #
     target_compile_definitions(vtkh_rendering_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/utils/CMakeLists.txt
+++ b/src/libs/vtkh/utils/CMakeLists.txt
@@ -37,7 +37,9 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_utils PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_utils PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_utils PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
 
     if(CUDA_FOUND)
         set_target_properties(vtkh_utils PROPERTIES LINKER_LANGUAGE CUDA)

--- a/src/libs/vtkh/utils/CMakeLists.txt
+++ b/src/libs/vtkh/utils/CMakeLists.txt
@@ -37,7 +37,7 @@ if (ENABLE_SERIAL)
 
     # build time only defs
     target_compile_definitions(vtkh_utils PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_utils PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_utils PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
     if(CUDA_FOUND)
         set_target_properties(vtkh_utils PROPERTIES LINKER_LANGUAGE CUDA)
@@ -75,7 +75,7 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_utils_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-    set_target_properties(vtkh_utils_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#    set_target_properties(vtkh_utils_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
     #
     target_compile_definitions(vtkh_utils_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/utils/CMakeLists.txt
+++ b/src/libs/vtkh/utils/CMakeLists.txt
@@ -77,7 +77,9 @@ if (MPI_FOUND)
 
     # build time only defs
     target_compile_definitions(vtkh_utils_mpi PRIVATE ASCENT_EXPORTS_FLAG)
-#    set_target_properties(vtkh_utils_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    if(ENABLE_HIDDEN_VISIBILITY)
+      set_target_properties(vtkh_utils_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    endif()
     #
     target_compile_definitions(vtkh_utils_mpi PRIVATE VTKH_PARALLEL)
 

--- a/src/libs/vtkh/vtkm_filters/CMakeLists.txt
+++ b/src/libs/vtkh/vtkm_filters/CMakeLists.txt
@@ -57,7 +57,9 @@ blt_add_library(NAME vtkm_compiled_filters
 
 vtkm_add_target_information(vtkm_compiled_filters DEVICE_SOURCES ${vtkm_filter_sources})
 
-#set_target_properties(vtkm_compiled_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
+if(ENABLE_HIDDEN_VISIBILITY)
+  set_target_properties(vtkm_compiled_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
 
 if(KOKKOS_FOUND)
       # vtkm + object libs are fun. Flags are not being propagated, so manually add them

--- a/src/libs/vtkh/vtkm_filters/CMakeLists.txt
+++ b/src/libs/vtkh/vtkm_filters/CMakeLists.txt
@@ -57,7 +57,7 @@ blt_add_library(NAME vtkm_compiled_filters
 
 vtkm_add_target_information(vtkm_compiled_filters DEVICE_SOURCES ${vtkm_filter_sources})
 
-set_target_properties(vtkm_compiled_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#set_target_properties(vtkm_compiled_filters PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 if(KOKKOS_FOUND)
       # vtkm + object libs are fun. Flags are not being propagated, so manually add them

--- a/src/rover/CMakeLists.txt
+++ b/src/rover/CMakeLists.txt
@@ -70,7 +70,7 @@ set_target_properties(rover PROPERTIES
                       CXX_STANDARD_REQUIRED YES
                       CXX_EXTENTIONS NO)
 
-set_target_properties(rover PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# set_target_properties(rover PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(rover PRIVATE ROVER_EXPORTS_FLAG)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty_builtin/diy2/include/)
@@ -129,7 +129,7 @@ if(MPI_FOUND)
 
                       blt_add_target_compile_flags(TO rover_mpi FLAGS "-DROVER_PARALLEL")
 
-  set_target_properties(rover_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+#  set_target_properties(rover_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
   target_compile_definitions(rover_mpi PRIVATE ROVER_EXPORTS_FLAG)
 
   target_include_directories(rover_mpi PRIVATE ${MPI_INCLUDE_PATH})

--- a/src/rover/CMakeLists.txt
+++ b/src/rover/CMakeLists.txt
@@ -70,7 +70,9 @@ set_target_properties(rover PROPERTIES
                       CXX_STANDARD_REQUIRED YES
                       CXX_EXTENTIONS NO)
 
-# set_target_properties(rover PROPERTIES CXX_VISIBILITY_PRESET hidden)
+if(ENABLE_HIDDEN_VISIBILITY)
+  set_target_properties(rover PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
 target_compile_definitions(rover PRIVATE ROVER_EXPORTS_FLAG)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty_builtin/diy2/include/)
@@ -129,7 +131,9 @@ if(MPI_FOUND)
 
                       blt_add_target_compile_flags(TO rover_mpi FLAGS "-DROVER_PARALLEL")
 
-#  set_target_properties(rover_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  if(ENABLE_HIDDEN_VISIBILITY)
+    set_target_properties(rover_mpi PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  endif()
   target_compile_definitions(rover_mpi PRIVATE ROVER_EXPORTS_FLAG)
 
   target_include_directories(rover_mpi PRIVATE ${MPI_INCLUDE_PATH})


### PR DESCRIPTION

    in order to avoid linker warnings
    in static application builds
    (see #1032) it is useful to
    provide users with an option
    to disable hidden visibility.
    ENABLE_HIDDEN_VISIBILITY will
    be ON by default but can be
    turned OFF by users who are
    experiencing issues with
    mixed levels of visibility.