### PR TITLE
Fix compile issues with diy vs hipcc

### DIFF
--- a/src/libs/apcomp/internal/diy/include/diy/master.hpp
+++ b/src/libs/apcomp/internal/diy/include/diy/master.hpp
@@ -86,6 +86,8 @@ namespace apcompdiy
       struct QueuePolicy
       {
                 QueuePolicy(size_t sz): size(sz)          {}
+                QueuePolicy(const QueuePolicy &p) size(p.size) {}
+               ~QueuePolicy() {}
         bool    unload_incoming(const Master&, int, int, size_t sz) const         { return sz > size; }
         bool    unload_outgoing(const Master& master, int from, size_t sz) const  { return sz > size*master.outgoing_count(from); }
 

--- a/src/libs/apcomp/internal/diy/include/diy/master.hpp
+++ b/src/libs/apcomp/internal/diy/include/diy/master.hpp
@@ -72,22 +72,26 @@ namespace apcompdiy
       template<class Block>
       using ICallback = std::function<bool(Block*, const ProxyWithLink&)>;
 
-      struct QueuePolicy
-      {
-        virtual bool    unload_incoming(const Master& master, int from, int to, size_t size) const  =0;
-        virtual bool    unload_outgoing(const Master& master, int from, size_t size) const          =0;
-        virtual         ~QueuePolicy() {}
-      };
+      // BEGIN ASCENT EDIT //
+      // Only use a single policy, avoid new of QueuePolicy
+      // due to issues with hipcc and def of delete operator
+      // struct QueuePolicy
+      // {
+      //   virtual bool    unload_incoming(const Master& master, int from, int to, size_t size) const  =0;
+      //   virtual bool    unload_outgoing(const Master& master, int from, size_t size) const          =0;
+      //   virtual         ~QueuePolicy() {}
+      // };
 
       //! Move queues out of core if their size exceeds a parameter given in the constructor
-      struct QueueSizePolicy: public QueuePolicy
+      struct QueuePolicy
       {
-                QueueSizePolicy(size_t sz): size(sz)          {}
+                QueuePolicy(size_t sz): size(sz)          {}
         bool    unload_incoming(const Master&, int, int, size_t sz) const         { return sz > size; }
         bool    unload_outgoing(const Master& master, int from, size_t sz) const  { return sz > size*master.outgoing_count(from); }
 
         size_t  size;
       };
+      // END ASCENT EDIT //
 
       // forward declarations, defined in detail/master/communication.hpp
       struct MessageInfo;
@@ -160,7 +164,9 @@ namespace apcompdiy
                            ExternalStorage*     storage   = 0,  //!< storage object (path, method, etc.) for storing temporary blocks being shuffled in/out of core
                            SaveBlock            save      = 0,  //!< block save function; master manages saving if save != 0
                            LoadBlock            load_     = 0,  //!< block load function; master manages loading if load != 0
-                           QueuePolicy*         q_policy  = new QueueSizePolicy(4096)); //!< policy for managing message queues specifies maximum size of message queues to keep in memory
+                           // BEGIN ASCENT EDIT //
+                           QueuePolicy          q_policy  = QueuePolicy(4096)); //!< policy for managing message queues specifies maximum size of message queues to keep in memory
+                           // END ASCENT EDIT //
       inline        ~Master();
 
       inline void   clear();
@@ -319,8 +325,9 @@ namespace apcompdiy
       Collection            blocks_;
       std::vector<int>      gids_;
       std::map<int, int>    lids_;
-
-      QueuePolicy*          queue_policy_;
+      // BEGIN ASCENT EDIT //
+      QueuePolicy           queue_policy_;
+      // END ASCENT EDIT //
 
       int                   limit_;
       int                   threads_;
@@ -369,7 +376,7 @@ Master(mpi::communicator    comm,
        ExternalStorage*     storage,
        SaveBlock            save,
        LoadBlock            load_,
-       QueuePolicy*         q_policy):
+       QueuePolicy          q_policy):
   blocks_(create_, destroy_, storage, save, load_),
   queue_policy_(q_policy),
   limit_(limit__),
@@ -388,7 +395,9 @@ apcompdiy::Master::
 {
     set_immediate(true);
     clear();
-    delete queue_policy_;
+    // BEGIN ASCENT EDIT //
+    //delete queue_policy_;
+    // END ASCENT EDIT //
 }
 
 void
@@ -437,7 +446,8 @@ unload_incoming(int gid__)
     for (InQueueRecords::iterator it = in_qrs.records.begin(); it != in_qrs.records.end(); ++it)
     {
       QueueRecord& qr = it->second;
-      if (queue_policy_->unload_incoming(*this, it->first, gid__, qr.size))
+      // ASCENT EDIT (queue_policy_ no longer a pointer)//
+      if (queue_policy_.unload_incoming(*this, it->first, gid__, qr.size))
       {
         log->debug("Unloading queue: {} <- {}", gid__, it->first);
         qr.external = storage_->put(in_qrs.queues[it->first]);
@@ -463,7 +473,8 @@ unload_outgoing(int gid__)
     out_queues_size += Serialization<MemoryBuffer>::size(rec.second);   // buffer contents
     ++count;
   }
-  if (queue_policy_->unload_outgoing(*this, gid__, out_queues_size - sizeof(size_t)))
+  // ASCENT EDIT (queue_policy_ no longer a pointer)//
+  if (queue_policy_.unload_outgoing(*this, gid__, out_queues_size - sizeof(size_t)))
   {
       log->debug("Unloading outgoing queues: {} -> ...; size = {}\n", gid__, out_queues_size);
       MemoryBuffer  bb;     bb.reserve(out_queues_size);
@@ -477,8 +488,9 @@ unload_outgoing(int gid__)
         auto& buffer = it->second;
         if (bid.proc == comm_.rank())
         {
+          // ASCENT EDIT (queue_policy_ no longer a pointer)//
           // treat as incoming
-          if (queue_policy_->unload_incoming(*this, gid__, bid.gid, buffer.size()))
+          if (queue_policy_.unload_incoming(*this, gid__, bid.gid, buffer.size()))
           {
             QueueRecord& qr = out_qr.external_local[bid];
             qr.size     = buffer.size();
@@ -1004,7 +1016,8 @@ send_same_rank(int from, int to, MemoryBuffer& bb, IExchangeInfo* iexchange)
     {
         log->debug("Unloading outgoing directly as incoming: {} <- {}", to, from);
         in_qr.size = bb.size();
-        if (queue_policy_->unload_incoming(*this, from, to, in_qr.size))
+        // ASCENT EDIT (queue_policy_ no longer a pointer)//
+        if (queue_policy_.unload_incoming(*this, from, to, in_qr.size))
             in_qr.external = storage_->put(bb);
         else
         {
@@ -1157,9 +1170,9 @@ check_incoming_queues(IExchangeInfo* iexchange)
         {
             assert(ir.info.round >= exchange_round_);
             IncomingRound* in = &incoming_[ir.info.round];
-
+            // ASCENT EDIT (queue_policy_ no longer a pointer)//
             bool unload = ((ir.info.round == exchange_round_) ? (block(lid(ir.info.to)) == 0) : (limit_ != -1))
-                          && queue_policy_->unload_incoming(*this, ir.info.from, ir.info.to, ir.message.size());
+                          && queue_policy_.unload_incoming(*this, ir.info.from, ir.info.to, ir.message.size());
 
             ir.place(in, unload, storage_, iexchange);
             ir.reset();

--- a/src/libs/apcomp/internal/diy/include/diy/master.hpp
+++ b/src/libs/apcomp/internal/diy/include/diy/master.hpp
@@ -86,7 +86,7 @@ namespace apcompdiy
       struct QueuePolicy
       {
                 QueuePolicy(size_t sz): size(sz)          {}
-                QueuePolicy(const QueuePolicy &p) size(p.size) {}
+                QueuePolicy(const QueuePolicy &p): size(p.size) {}
                ~QueuePolicy() {}
         bool    unload_incoming(const Master&, int, int, size_t sz) const         { return sz > size; }
         bool    unload_outgoing(const Master& master, int from, size_t sz) const  { return sz > size*master.outgoing_count(from); }

--- a/src/libs/vtkh/compositing/internal/diy/include/diy/master.hpp
+++ b/src/libs/vtkh/compositing/internal/diy/include/diy/master.hpp
@@ -85,6 +85,8 @@ namespace vtkhdiy
       struct QueuePolicy
       {
                 QueuePolicy(size_t sz): size(sz)          {}
+                QueuePolicy(const QueuePolicy &p) size(p.size) {}
+               ~QueuePolicy() {}
         bool    unload_incoming(const Master& master, int from, int to, size_t sz) const    { return sz > size; }
         bool    unload_outgoing(const Master& master, int from, size_t sz) const            { return sz > size*master.outgoing_count(from); }
 

--- a/src/libs/vtkh/compositing/internal/diy/include/diy/master.hpp
+++ b/src/libs/vtkh/compositing/internal/diy/include/diy/master.hpp
@@ -85,7 +85,7 @@ namespace vtkhdiy
       struct QueuePolicy
       {
                 QueuePolicy(size_t sz): size(sz)          {}
-                QueuePolicy(const QueuePolicy &p) size(p.size) {}
+                QueuePolicy(const QueuePolicy &p): size(p.size) {}
                ~QueuePolicy() {}
         bool    unload_incoming(const Master& master, int from, int to, size_t sz) const    { return sz > size; }
         bool    unload_outgoing(const Master& master, int from, size_t sz) const            { return sz > size*master.outgoing_count(from); }


### PR DESCRIPTION
resolves: https://github.com/Alpine-DAV/ascent/issues/1013

There is only one subclass of QueuePolicy (QueueSize)Policy simplify so that the subclass becomes QueuePolicy so we can avoid using pointers and the strange host device decoration issue with the standard delete operator. 
