### PR TITLE
Fix power/xl compile errors

### DIFF
--- a/src/libs/ascent/runtimes/expressions/ascent_jit_topology.cpp
+++ b/src/libs/ascent/runtimes/expressions/ascent_jit_topology.cpp
@@ -13,7 +13,7 @@
 #include "ascent_jit_topology.hpp"
 #include <ascent_logging.hpp>
 #include "ascent_blueprint_topologies.hpp"
-#include <math.h>
+#include <cmath>
 
 //-----------------------------------------------------------------------------
 // -- begin ascent:: --

--- a/src/libs/dray/types.hpp
+++ b/src/libs/dray/types.hpp
@@ -13,7 +13,7 @@ typedef unsigned char uint8;
 typedef unsigned int uint32;
 typedef unsigned long long int uint64;
 
-typedef char int8;
+typedef signed char int8;
 typedef int int32;
 typedef long long int int64;
 


### PR DESCRIPTION
* POWER's char is unsigned, which caused an error: `src/libs/dray/filters/internal/marching_cubes_lookup_tables.hpp:77:41: error: constant expression evaluates to -1 which cannot be narrowed to type 'int8' (aka 'char')`
* `math.h` doesn't include the `std` variant, which caused `error: no member named 'pow' in namespace 'std';`
