### PR TITLE
Extend RAJA search path to try RAJA_DIR itself

### DIFF
--- a/src/cmake/thirdparty/SetupRAJA.cmake
+++ b/src/cmake/thirdparty/SetupRAJA.cmake
@@ -12,9 +12,12 @@ set(_RAJA_SEARCH_PATH)
 if(EXISTS ${RAJA_DIR}/share/raja/cmake)
   # old install layout
   set(_RAJA_SEARCH_PATH ${RAJA_DIR}/share/raja/cmake)
-else()
+elseif(EXISTS ${RAJA_DIR}/lib/cmake/raja)
   # new install layout
   set(_RAJA_SEARCH_PATH ${RAJA_DIR}/lib/cmake/raja)
+else ()
+  # try RAJA_DIR itself
+  set(_RAJA_SEARCH_PATH ${RAJA_DIR})
 endif()
 
 message(STATUS "Looking for RAJA in: ${RAJA_DIR}")

--- a/src/config/ascent_setup_deps.cmake
+++ b/src/config/ascent_setup_deps.cmake
@@ -218,11 +218,14 @@ if(RAJA_DIR)
     if(EXISTS ${RAJA_DIR}/share/raja/cmake)
       # old install layout
       set(_RAJA_SEARCH_PATH ${RAJA_DIR}/share/raja/cmake)
-    else()
+    elseif(EXISTS ${RAJA_DIR}/lib/cmake/raja)
       # new install layout
       set(_RAJA_SEARCH_PATH ${RAJA_DIR}/lib/cmake/raja)
+    else ()
+      # try RAJA_DIR itself
+      set(_RAJA_SEARCH_PATH ${RAJA_DIR})
     endif()
-    
+
     if(NOT EXISTS ${_RAJA_SEARCH_PATH})
         message(FATAL_ERROR "Could not find RAJA CMake include file (${_RAJA_SEARCH_PATH})")
     endif()


### PR DESCRIPTION
To find RAJA, ascent has been making assumptions about the form of `_RAJA_SEARCH_PATH`, namely that RAJA will **_only_** be located in either `RAJA_DIR/share/raja/cmake` (old) or `RAJA_DIR/lib/cmake/raja/` (new).

Downstream usage of ascent may assume that `RAJA_DIR` is the cmake root for RAJA--**this is what spack currently assumes**--but this breaks with your current model.

This change allows ascent to search `RAJA_DIR` for `RAJAConfig.cmake` itself.

_Note: The typical CMake way of accomplishing your desired functionality is by providing multiple `PATHS` ([docs](https://cmake.org/cmake/help/latest/command/find_package.html#full-signature)). CMake will search the directory structure for you._ 

Thanks to @kwryankrattiger for help with this fix.