### PR TITLE
Use Cray compiler wrappers in manual Polaris builds

### DIFF
--- a/scripts/build_ascent/build_ascent.sh
+++ b/scripts/build_ascent/build_ascent.sh
@@ -434,6 +434,7 @@ raja_src_dir=$(ospath ${root_dir}/RAJA-${raja_version})
 raja_build_dir=$(ospath ${root_dir}/build/raja-${raja_version})
 raja_install_dir=$(ospath ${root_dir}/install/raja-${raja_version}/)
 raja_tarball=RAJA-${raja_version}.tar.gz
+raja_enable_vectorization="${raja_enable_vectorization:=ON}"
 
 # build only if install doesn't exist
 if [ ! -d ${raja_install_dir} ]; then
@@ -471,7 +472,8 @@ cmake -S ${raja_src_dir} -B ${raja_build_dir} ${cmake_compiler_settings} \
   -DRAJA_ENABLE_TESTS=${enable_tests} \
   -DENABLE_EXAMPLES=${enable_tests} \
   -DENABLE_EXERCISES=${enable_tests} ${raja_extra_cmake_args} \
-  -DCMAKE_INSTALL_PREFIX=${raja_install_dir}
+  -DCMAKE_INSTALL_PREFIX=${raja_install_dir} \
+  -DRAJA_ENABLE_VECTORIZATION=${raja_enable_vectorization}
 
 echo "**** Building RAJA ${raja_version}"
 cmake --build ${raja_build_dir} --config ${build_config} -j${build_jobs}

--- a/scripts/build_ascent/build_ascent_cuda_polaris.sh
+++ b/scripts/build_ascent/build_ascent_cuda_polaris.sh
@@ -2,10 +2,10 @@ module load cmake
 
 # Swap NVHPC with GNU compilers
 module swap PrgEnv-nvhpc PrgEnv-gnu
-module load nvhpc-mixed
+module load cudatoolkit-standalone/11.8.0
 
-export CC=$(which gcc)
-export CXX=$(which g++)
-export FTN=$(which gfortran)
+export CC=$(which cc)
+export CXX=$(which CC)
+export FTN=$(which ftn)
 
-env enable_mpi=ON ./build_ascent_cuda.sh
+env enable_mpi=ON enable_fortran=ON raja_enable_vectorization=OFF ./build_ascent_cuda.sh

--- a/scripts/build_ascent/build_ascent_cuda_polaris.sh
+++ b/scripts/build_ascent/build_ascent_cuda_polaris.sh
@@ -2,7 +2,7 @@ module load cmake
 
 # Swap NVHPC with GNU compilers
 module swap PrgEnv-nvhpc PrgEnv-gnu
-module load cudatoolkit-standalone/11.8.0
+module load cudatoolkit-standalone
 
 export CC=$(which cc)
 export CXX=$(which CC)


### PR DESCRIPTION
Improves upon #1148, the Cray compiler wrappers are now used to build on Polaris instead of using gcc, g++, and gfortran directly. It turns out that the ALCF documentation I originally referenced for how to swap from NVHPC to GCC was not correct.

Just one caveat here: compiling RAJA with the updated script runs into [this error](https://github.com/LLNL/RAJA/issues/1464#issue-1642591604). The fix is to set `-D RAJA_ENABLE_VECTORIZATION=OFF` when building RAJA, which defaults to `ON`.

There are several ways to get around this, and I wasn't sure what the preferred way would be. I settled on making it an option that leaves the default alone, but lets me disable it for Polaris builds specifically. Would appreciate your thoughts, I'm happy to change it however you think is best.