### PR TITLE
set background and foreground color before blend

### DIFF
--- a/src/libs/vtkh/rendering/Render.cpp
+++ b/src/libs/vtkh/rendering/Render.cpp
@@ -275,7 +275,12 @@ Render::Print() const
 void
 Render::RenderBackground()
 {
-  if(m_render_background) m_canvas.BlendBackground();
+  if(m_render_background)
+  {
+    m_canvas.SetBackgroundColor(m_bg_color);
+    m_canvas.SetForegroundColor(m_fg_color);
+    m_canvas.BlendBackground();
+  }
 }
 
 Render::vtkmCanvas


### PR DESCRIPTION
Looks like if all annotations are off we may miss setting bg/fg correctly. 