### PR TITLE
Fixed ascent clone path

### DIFF
--- a/scripts/build_ascent/build_ascent.sh
+++ b/scripts/build_ascent/build_ascent.sh
@@ -1031,7 +1031,7 @@ if [ ! -d ${ascent_install_dir} ]; then
 if ${build_ascent}; then
 if [ ! -d ${ascent_src_dir} ]; then
     echo "**** Cloning Ascent"
-    git clone --recursive https://github.com/Alpine-DAV/ascent.git
+    git clone --recursive https://github.com/Alpine-DAV/ascent.git ${source_dir}/ascent
 fi
 
 echo "**** Configuring Ascent"


### PR DESCRIPTION
The path is incorrect if script is standalone.
This PR fixes the path in the case that the script needs to clone ascent.