### PR TITLE
resolve a compilation error of VTK-m with CUDA 12.6

### DIFF
--- a/scripts/build_ascent/2025_04_29_vtkm_cuda12.6_compilefix.patch
+++ b/scripts/build_ascent/2025_04_29_vtkm_cuda12.6_compilefix.patch
@@ -1,0 +1,22 @@
+--- vtkm/exec/cuda/internal/WrappedOperators.h	2025-04-29 08:30:18.471616022 +0200
++++ /local/apps/vtk-m/vtkm/exec/cuda/internal/WrappedOperators.h	2024-08-20 11:22:29.754010727 +0200
+@@ -197,11 +197,19 @@
+ // the binary functor is commutative and the T type is is_arithmetic
+ //
+ //
++#if THRUST_VERSION >= 200500
++template <typename T, typename F>
++struct is_commutative<vtkm::exec::cuda::internal::WrappedBinaryOperator<T, F>>
++  : public ::cuda::std::is_arithmetic<T>
++{
++};
++#else
+ template <typename T, typename F>
+ struct is_commutative<vtkm::exec::cuda::internal::WrappedBinaryOperator<T, F>>
+   : public thrust::detail::is_arithmetic<T>
+ {
+ };
++#endif
+ }
+ } //namespace thrust::detail
+ 

--- a/scripts/build_ascent/build_ascent.sh
+++ b/scripts/build_ascent/build_ascent.sh
@@ -656,6 +656,10 @@ if [ ! -d ${vtkm_src_dir} ]; then
   curl -L https://gitlab.kitware.com/vtk/vtk-m/-/archive/${vtkm_version}/vtk-m-${vtkm_version}.tar.gz -o ${vtkm_tarball}
   tar ${tar_extra_args} -xzf ${vtkm_tarball} -C ${source_dir}
 
+  # apply vtk-m patch
+  cd  ${vtkm_src_dir}
+  patch -p4 < ${script_dir}/2025_04_29_vtkm_cuda12.6_compilefix.patch
+  cd ${root_dir}
 fi
 
 


### PR DESCRIPTION
we resolve https://github.com/Alpine-DAV/ascent/issues/1506 by applying the same patch used in vtkm-2.3 source code.