### PR TITLE
Fix conflicting family value found in output test file names

### DIFF
--- a/src/tests/t_utils.hpp
+++ b/src/tests/t_utils.hpp
@@ -687,7 +687,7 @@ add_matset_to_spiral(Node &n_mesh, const int ndomains)
 #define ASCENT_ACTIONS_DUMP(actions,name,msg) \
   std::string actions_str = actions.to_yaml(); \
   std::ofstream out; \
-  out.open(name+"100"+".yaml"); \
+  out.open(name+"100_actions.yaml"); \
   out<<"#"<<msg<<"\n"; \
   out<<actions_str; \
   out.close();


### PR DESCRIPTION
Temporary fix to get the tests working again. Solves the problem that when tests are run multiple times that they start to fail because of naming conflicts even with different extensions. Will revert this change when file name extensions fix is added