### PR TITLE
Rover width, height cleanup + adds settings used to the output

### DIFF
--- a/src/libs/rover/image.cpp
+++ b/src/libs/rover/image.cpp
@@ -46,7 +46,9 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle,
   FloatType inv_delta;
   inv_delta = min_scalar == max_scalar ? 1.f : 1.f / (max_scalar - min_scalar);
   auto portal = handle.WritePortal();
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
 #ifdef ROVER_OPENMP_ENABLED
   #pragma omp parallel for
 #endif
@@ -79,7 +81,9 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle, b
   FloatType inv_delta;
   inv_delta = min_scalar == max_scalar ? 1.f : 1.f / (max_scalar - min_scalar);
   auto portal = handle.WritePortal();
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
 #ifdef ROVER_OPENMP_ENABLED
   #pragma omp parallel for
 #endif
@@ -94,8 +98,6 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle, b
 
 template<typename FloatType>
 Image<FloatType>::Image()
-  : m_width(0),
-    m_height(0)
 {
 
 }
@@ -134,8 +136,6 @@ void cast_array_handle(vtkm::cont::ArrayHandle<T> &cast_to,
 //
 template<typename T, typename O> void init_from_image(Image<T> &left, Image<O> &right)
 {
-  left.m_height = right.m_height;
-  left.m_width = right.m_width;
   left.m_valid_intensities = right.m_valid_intensities;
   left.m_valid_optical_depths = right.m_valid_optical_depths;
 
@@ -150,8 +150,6 @@ template<typename T, typename O> void init_from_image(Image<T> &left, Image<O> &
 template<> void init_from_image<vtkm::Float32, vtkm::Float32>(Image<vtkm::Float32> &left,
                                                               Image<vtkm::Float32> &right)
 {
-  left.m_height = right.m_height;;
-  left.m_width = right.m_width;
   left.m_intensities = right.m_intensities;
   left.m_optical_depths = right.m_optical_depths;
   left.m_valid_intensities = right.m_valid_intensities;
@@ -161,8 +159,6 @@ template<> void init_from_image<vtkm::Float32, vtkm::Float32>(Image<vtkm::Float3
 template<> void init_from_image<vtkm::Float64, vtkm::Float64>(Image<vtkm::Float64> &left,
                                                               Image<vtkm::Float64> &right)
 {
-  left.m_height = right.m_height;;
-  left.m_width = right.m_width;
   left.m_intensities = right.m_intensities;
   left.m_optical_depths = right.m_optical_depths;
   left.m_valid_intensities = right.m_valid_intensities;
@@ -227,18 +223,15 @@ Image<FloatType>::init_from_partial(PartialImage<FloatType> &partial)
   m_valid_intensities.clear();
   m_valid_optical_depths.clear();
 
-  m_height = partial.m_height;
-  m_width  = partial.m_width;
-
-  assert(m_width >= 0);
-  assert(m_height >= 0);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
 
   const int num_channels = partial.m_buffer.GetNumChannels();
   for(int i = 0; i < num_channels; ++i)
   {
     vtkmRayTracing::ChannelBuffer<FloatType> channel = partial.m_buffer.GetChannel( i );
     const FloatType default_value = partial.m_source_sig.size() != 0 ? partial.m_source_sig[i] : 0.0f;
-    const int channel_size = m_height * m_width;
+    const int channel_size = height * width;
     vtkmRayTracing::ChannelBuffer<FloatType>  expand;
     expand = channel.ExpandBuffer(partial.m_pixel_ids,
                                   channel_size,
@@ -253,7 +246,7 @@ Image<FloatType>::init_from_partial(PartialImage<FloatType> &partial)
   {
     vtkmRayTracing::ChannelBuffer<FloatType> channel = partial.m_intensities.GetChannel( i );
     const FloatType default_value = partial.m_source_sig.size() != 0 ? partial.m_source_sig[i] : 0.0f;
-    const int channel_size = m_height * m_width;
+    const int channel_size = height * width;
     vtkmRayTracing::ChannelBuffer<FloatType>  expand;
     expand = channel.ExpandBuffer(partial.m_pixel_ids,
                                   channel_size,
@@ -309,7 +302,9 @@ Image<FloatType>::flatten_intensities()
     }
   }
   HandleType res;
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();
   for(int c = 0; c < num_channels; ++c)
@@ -340,7 +335,9 @@ Image<FloatType>::flatten_optical_depths()
     }
   }
   HandleType res;
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+    const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();
   for(int c = 0; c < num_channels; ++c)
@@ -361,7 +358,9 @@ template<typename FloatType>
 int
 Image<FloatType>::get_size()
 {
-  return  m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  return  width * height;
 }
 
 template<typename FloatType>

--- a/src/libs/rover/image.cpp
+++ b/src/libs/rover/image.cpp
@@ -336,7 +336,7 @@ Image<FloatType>::flatten_optical_depths()
   }
   HandleType res;
   const int32 width = rover::settings["rover/width"].value();
-    const int32 height = rover::settings["rover/height"].value();
+  const int32 height = rover::settings["rover/height"].value();
   const int size = width * height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();

--- a/src/libs/rover/image.cpp
+++ b/src/libs/rover/image.cpp
@@ -47,7 +47,9 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle,
   FloatType inv_delta;
   inv_delta = min_scalar == max_scalar ? 1.f : 1.f / (max_scalar - min_scalar);
   auto portal = handle.WritePortal();
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
 #ifdef ROVER_OPENMP_ENABLED
   #pragma omp parallel for
 #endif
@@ -80,7 +82,9 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle, b
   FloatType inv_delta;
   inv_delta = min_scalar == max_scalar ? 1.f : 1.f / (max_scalar - min_scalar);
   auto portal = handle.WritePortal();
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
 #ifdef ROVER_OPENMP_ENABLED
   #pragma omp parallel for
 #endif
@@ -96,15 +100,12 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle, b
 template<typename FloatType>
 Image<FloatType>::Image()
 {
-  m_width = rover::settings["rover/width"].value();
-  m_height = rover::settings["rover/height"].value();
+
 }
 
 template<typename FloatType>
 Image<FloatType>::Image(PartialImage<FloatType> &partial)
 {
-  m_width = rover::settings["rover/width"].value();
-  m_height = rover::settings["rover/height"].value();
   this->init_from_partial(partial);
 }
 
@@ -223,7 +224,9 @@ Image<FloatType>::init_from_partial(PartialImage<FloatType> &partial)
   m_valid_intensities.clear();
   m_valid_optical_depths.clear();
 
-  const int channel_size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int channel_size = width * height;
   const int num_channels = partial.m_buffer.GetNumChannels();
   for (int i = 0; i < num_channels; ++i)
   {
@@ -293,7 +296,9 @@ Image<FloatType>::flatten_intensities()
     }
   }
   HandleType res;
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();
   for(int c = 0; c < num_channels; ++c)
@@ -324,7 +329,9 @@ Image<FloatType>::flatten_optical_depths()
     }
   }
   HandleType res;
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();
   for(int c = 0; c < num_channels; ++c)
@@ -345,7 +352,9 @@ template<typename FloatType>
 int
 Image<FloatType>::get_size()
 {
-  return m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  return width * height;
 }
 
 template<typename FloatType>

--- a/src/libs/rover/image.cpp
+++ b/src/libs/rover/image.cpp
@@ -223,37 +223,31 @@ Image<FloatType>::init_from_partial(PartialImage<FloatType> &partial)
   m_valid_intensities.clear();
   m_valid_optical_depths.clear();
 
+  const int channel_size = m_width * m_height;
   const int num_channels = partial.m_buffer.GetNumChannels();
-  for(int i = 0; i < num_channels; ++i)
+  for (int i = 0; i < num_channels; ++i)
   {
     vtkmRayTracing::ChannelBuffer<FloatType> channel = partial.m_buffer.GetChannel( i );
     const FloatType default_value = partial.m_source_sig.size() != 0 ? partial.m_source_sig[i] : 0.0f;
-    const int channel_size = m_width * m_height;
     vtkmRayTracing::ChannelBuffer<FloatType>  expand;
     expand = channel.ExpandBuffer(partial.m_pixel_ids,
                                   channel_size,
                                   default_value);
-
     m_optical_depths.push_back(expand.Buffer);
     m_valid_optical_depths.push_back(true);
-
   }
 
-  for(int i = 0; i < num_channels; ++i)
+  for (int i = 0; i < num_channels; ++i)
   {
     vtkmRayTracing::ChannelBuffer<FloatType> channel = partial.m_intensities.GetChannel( i );
     const FloatType default_value = partial.m_source_sig.size() != 0 ? partial.m_source_sig[i] : 0.0f;
-    const int channel_size = m_width * m_height;
     vtkmRayTracing::ChannelBuffer<FloatType>  expand;
     expand = channel.ExpandBuffer(partial.m_pixel_ids,
                                   channel_size,
                                   default_value);
-
     m_intensities.push_back(expand.Buffer);
     m_valid_intensities.push_back(true);
-
   }
-
 }
 
 template<typename FloatType>

--- a/src/libs/rover/image.cpp
+++ b/src/libs/rover/image.cpp
@@ -4,6 +4,7 @@
 // other details. No copyright assignment is required to contribute to Ascent.
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "settings.hpp"
 #include <image.hpp>
 #include <rover_exceptions.hpp>
 #include <utils/rover_logging.hpp>
@@ -46,9 +47,7 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle,
   FloatType inv_delta;
   inv_delta = min_scalar == max_scalar ? 1.f : 1.f / (max_scalar - min_scalar);
   auto portal = handle.WritePortal();
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  const int size = width * height;
+  const int size = m_width * m_height;
 #ifdef ROVER_OPENMP_ENABLED
   #pragma omp parallel for
 #endif
@@ -81,9 +80,7 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle, b
   FloatType inv_delta;
   inv_delta = min_scalar == max_scalar ? 1.f : 1.f / (max_scalar - min_scalar);
   auto portal = handle.WritePortal();
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  const int size = width * height;
+  const int size = m_width * m_height;
 #ifdef ROVER_OPENMP_ENABLED
   #pragma omp parallel for
 #endif
@@ -99,12 +96,15 @@ Image<FloatType>::normalize_handle(vtkm::cont::ArrayHandle<FloatType> &handle, b
 template<typename FloatType>
 Image<FloatType>::Image()
 {
-
+  m_width = rover::settings["rover/width"].value();
+  m_height = rover::settings["rover/height"].value();
 }
 
 template<typename FloatType>
 Image<FloatType>::Image(PartialImage<FloatType> &partial)
 {
+  m_width = rover::settings["rover/width"].value();
+  m_height = rover::settings["rover/height"].value();
   this->init_from_partial(partial);
 }
 
@@ -223,15 +223,12 @@ Image<FloatType>::init_from_partial(PartialImage<FloatType> &partial)
   m_valid_intensities.clear();
   m_valid_optical_depths.clear();
 
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-
   const int num_channels = partial.m_buffer.GetNumChannels();
   for(int i = 0; i < num_channels; ++i)
   {
     vtkmRayTracing::ChannelBuffer<FloatType> channel = partial.m_buffer.GetChannel( i );
     const FloatType default_value = partial.m_source_sig.size() != 0 ? partial.m_source_sig[i] : 0.0f;
-    const int channel_size = height * width;
+    const int channel_size = m_width * m_height;
     vtkmRayTracing::ChannelBuffer<FloatType>  expand;
     expand = channel.ExpandBuffer(partial.m_pixel_ids,
                                   channel_size,
@@ -246,7 +243,7 @@ Image<FloatType>::init_from_partial(PartialImage<FloatType> &partial)
   {
     vtkmRayTracing::ChannelBuffer<FloatType> channel = partial.m_intensities.GetChannel( i );
     const FloatType default_value = partial.m_source_sig.size() != 0 ? partial.m_source_sig[i] : 0.0f;
-    const int channel_size = height * width;
+    const int channel_size = m_width * m_height;
     vtkmRayTracing::ChannelBuffer<FloatType>  expand;
     expand = channel.ExpandBuffer(partial.m_pixel_ids,
                                   channel_size,
@@ -302,9 +299,7 @@ Image<FloatType>::flatten_intensities()
     }
   }
   HandleType res;
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  const int size = width * height;
+  const int size = m_width * m_height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();
   for(int c = 0; c < num_channels; ++c)
@@ -335,9 +330,7 @@ Image<FloatType>::flatten_optical_depths()
     }
   }
   HandleType res;
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  const int size = width * height;
+  const int size = m_width * m_height;
   res.Allocate(num_channels * size);
   auto output = res.WritePortal();
   for(int c = 0; c < num_channels; ++c)
@@ -358,9 +351,7 @@ template<typename FloatType>
 int
 Image<FloatType>::get_size()
 {
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  return  width * height;
+  return m_width * m_height;
 }
 
 template<typename FloatType>

--- a/src/libs/rover/image.hpp
+++ b/src/libs/rover/image.hpp
@@ -51,6 +51,8 @@ protected:
   std::vector<HandleType>                  m_optical_depths;
   std::vector<bool>                        m_valid_intensities;
   std::vector<bool>                        m_valid_optical_depths;
+  int                                      m_width;
+  int                                      m_height;
 
   void init_from_partial(PartialImage<FloatType> &);
   void normalize_handle(HandleType &, bool);

--- a/src/libs/rover/image.hpp
+++ b/src/libs/rover/image.hpp
@@ -47,12 +47,12 @@ public:
                                                    Image<O> &right);
 
 protected:
+  int32                                    m_width;
+  int32                                    m_height;
   std::vector<HandleType>                  m_intensities;
   std::vector<HandleType>                  m_optical_depths;
   std::vector<bool>                        m_valid_intensities;
   std::vector<bool>                        m_valid_optical_depths;
-  int                                      m_width;
-  int                                      m_height;
 
   void init_from_partial(PartialImage<FloatType> &);
   void normalize_handle(HandleType &, bool);

--- a/src/libs/rover/image.hpp
+++ b/src/libs/rover/image.hpp
@@ -47,8 +47,6 @@ public:
                                                    Image<O> &right);
 
 protected:
-  int32                                    m_width;
-  int32                                    m_height;
   std::vector<HandleType>                  m_intensities;
   std::vector<HandleType>                  m_optical_depths;
   std::vector<bool>                        m_valid_intensities;

--- a/src/libs/rover/image.hpp
+++ b/src/libs/rover/image.hpp
@@ -47,8 +47,6 @@ public:
                                                    Image<O> &right);
 
 protected:
-  int                                      m_height;
-  int                                      m_width;
   std::vector<HandleType>                  m_intensities;
   std::vector<HandleType>                  m_optical_depths;
   std::vector<bool>                        m_valid_intensities;

--- a/src/libs/rover/partial_image.hpp
+++ b/src/libs/rover/partial_image.hpp
@@ -7,7 +7,6 @@
 #ifndef rover_partial_image_h
 #define rover_partial_image_h
 
-#include <cstdint>
 #include <rover_config.h>
 #include <settings.hpp>
 #include <vtkm_typedefs.hpp>

--- a/src/libs/rover/partial_image.hpp
+++ b/src/libs/rover/partial_image.hpp
@@ -7,6 +7,7 @@
 #ifndef rover_partial_image_h
 #define rover_partial_image_h
 
+#include <cstdint>
 #include <rover_config.h>
 #include <settings.hpp>
 #include <vtkm_typedefs.hpp>
@@ -29,6 +30,8 @@ struct PartialImage
   vtkmRayTracing::ChannelBuffer<FloatType> m_intensities;     // holds the intensity emerging from each ray
   vtkm::cont::ArrayHandle<FloatType>       m_distances;
   std::vector<FloatType>                   m_source_sig;
+  int                                      m_width;
+  int                                      m_height;
 
   void allocate(const vtkm::Id &size, const vtkm::Id &channels)
   {
@@ -44,7 +47,8 @@ struct PartialImage
 
   PartialImage()
   {
-
+    m_width = rover::settings["rover/width"].value();
+    m_height = rover::settings["rover/height"].value();
   }
 
 #if 0 // removing volume renderer
@@ -288,9 +292,7 @@ struct PartialImage
     const int size = m_pixel_ids.GetNumberOfValues();
     const int num_channels = m_buffer.GetNumChannels();
     bool has_emission = m_intensities.Buffer.GetNumberOfValues() != 0;
-    const int32 width = rover::settings["rover/width"].value();
-    const int32 height = rover::settings["rover/height"].value();
-    int debug = width * (height - y) + x;
+    int debug = m_width * (m_height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {
@@ -315,9 +317,7 @@ struct PartialImage
   {
     const int size = m_pixel_ids.GetNumberOfValues();
     const int num_channels = m_buffer.GetNumChannels();
-    const int32 width = rover::settings["rover/width"].value();
-    const int32 height = rover::settings["rover/height"].value();
-    int debug = width * (height - y) + x;
+    int debug = m_width * (m_height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {

--- a/src/libs/rover/partial_image.hpp
+++ b/src/libs/rover/partial_image.hpp
@@ -25,13 +25,13 @@ namespace rover
 template<typename FloatType>
 struct PartialImage
 {
+  int32                                    m_width;
+  int32                                    m_height;
   IdHandle                                 m_pixel_ids;
   vtkmRayTracing::ChannelBuffer<FloatType> m_buffer;          // holds the absorption
   vtkmRayTracing::ChannelBuffer<FloatType> m_intensities;     // holds the intensity emerging from each ray
   vtkm::cont::ArrayHandle<FloatType>       m_distances;
   std::vector<FloatType>                   m_source_sig;
-  int                                      m_width;
-  int                                      m_height;
 
   void allocate(const vtkm::Id &size, const vtkm::Id &channels)
   {

--- a/src/libs/rover/partial_image.hpp
+++ b/src/libs/rover/partial_image.hpp
@@ -8,6 +8,8 @@
 #define rover_partial_image_h
 
 #include <rover_config.h>
+#include <settings.hpp>
+#include <vtkm_typedefs.hpp>
 
 #include <vector>
 
@@ -22,8 +24,6 @@ namespace rover
 template<typename FloatType>
 struct PartialImage
 {
-  int                                      m_height;
-  int                                      m_width;
   IdHandle                                 m_pixel_ids;
   vtkmRayTracing::ChannelBuffer<FloatType> m_buffer;          // holds the absorption
   vtkmRayTracing::ChannelBuffer<FloatType> m_intensities;     // holds the intensity emerging from each ray
@@ -43,8 +43,6 @@ struct PartialImage
   }
 
   PartialImage()
-    : m_height(0),
-      m_width(0)
   {
 
   }
@@ -183,12 +181,8 @@ struct PartialImage
 #endif
 
   void store(std::vector<vtkh::AbsorptionPartial<FloatType>> &partials,
-             const std::vector<double> &background,
-             const int width,
-             const int height)
+             const std::vector<double> &background)
   {
-    m_width = width;
-    m_height = height;
     const int size = static_cast<int>(partials.size());
     const int num_bins = static_cast<int>(partials.at(0).m_bins.size());
     allocate(size,num_bins);
@@ -221,12 +215,8 @@ struct PartialImage
   }
 
   void store(std::vector<vtkh::EmissionPartial<FloatType>> &partials,
-             const std::vector<double> &background,
-             const int width,
-             const int height)
+             const std::vector<double> &background)
   {
-    m_width = width;
-    m_height = height;
     const int size = static_cast<int>(partials.size());
     const int num_bins = static_cast<int>(partials.at(0).m_bins.size());
     allocate(size,num_bins);
@@ -298,7 +288,9 @@ struct PartialImage
     const int size = m_pixel_ids.GetNumberOfValues();
     const int num_channels = m_buffer.GetNumChannels();
     bool has_emission = m_intensities.Buffer.GetNumberOfValues() != 0;
-    int debug = m_width * ( m_height - y) + x;
+    const int32 width = rover::settings["rover/width"].value();
+    const int32 height = rover::settings["rover/height"].value();
+    int debug = width * ( height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {
@@ -323,7 +315,9 @@ struct PartialImage
   {
     const int size = m_pixel_ids.GetNumberOfValues();
     const int num_channels = m_buffer.GetNumChannels();
-    int debug = m_width * ( m_height - y) + x;
+    const int32 width = rover::settings["rover/width"].value();
+    const int32 height = rover::settings["rover/height"].value();
+    int debug = width * (height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {

--- a/src/libs/rover/partial_image.hpp
+++ b/src/libs/rover/partial_image.hpp
@@ -290,7 +290,7 @@ struct PartialImage
     bool has_emission = m_intensities.Buffer.GetNumberOfValues() != 0;
     const int32 width = rover::settings["rover/width"].value();
     const int32 height = rover::settings["rover/height"].value();
-    int debug = width * ( height - y) + x;
+    int debug = width * (height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {

--- a/src/libs/rover/partial_image.hpp
+++ b/src/libs/rover/partial_image.hpp
@@ -25,8 +25,6 @@ namespace rover
 template<typename FloatType>
 struct PartialImage
 {
-  int32                                    m_width;
-  int32                                    m_height;
   IdHandle                                 m_pixel_ids;
   vtkmRayTracing::ChannelBuffer<FloatType> m_buffer;          // holds the absorption
   vtkmRayTracing::ChannelBuffer<FloatType> m_intensities;     // holds the intensity emerging from each ray
@@ -47,8 +45,7 @@ struct PartialImage
 
   PartialImage()
   {
-    m_width = rover::settings["rover/width"].value();
-    m_height = rover::settings["rover/height"].value();
+
   }
 
 #if 0 // removing volume renderer
@@ -287,12 +284,15 @@ struct PartialImage
     }
   }
 
+  // TODO: Investigate if we need this
   void print_pixel(const int x, const int y)
   {
     const int size = m_pixel_ids.GetNumberOfValues();
     const int num_channels = m_buffer.GetNumChannels();
-    bool has_emission = m_intensities.Buffer.GetNumberOfValues() != 0;
-    int debug = m_width * (m_height - y) + x;
+    const bool has_emission = m_intensities.Buffer.GetNumberOfValues() != 0;
+    const int32 width = rover::settings["rover/width"].value();
+    const int32 height = rover::settings["rover/height"].value();
+    const int debug = width * (height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {
@@ -313,11 +313,14 @@ struct PartialImage
 
   }// print
 
+  // TODO: Investigate if we need this
   void make_red_pixel(const int x, const int y)
   {
     const int size = m_pixel_ids.GetNumberOfValues();
     const int num_channels = m_buffer.GetNumChannels();
-    int debug = m_width * (m_height - y) + x;
+    const int32 width = rover::settings["rover/width"].value();
+    const int32 height = rover::settings["rover/height"].value();
+    const int debug = width * (height - y) + x;
 
     for(int i = 0; i < size; ++i)
     {
@@ -333,8 +336,7 @@ struct PartialImage
       }
     }
   }
-
-
 };
+
 } // namespace rover
 #endif

--- a/src/libs/rover/ray_generators/camera_generator.cpp
+++ b/src/libs/rover/ray_generators/camera_generator.cpp
@@ -66,12 +66,11 @@ CameraGenerator::get_rays(vtkmRayTracing::Ray<vtkm::Float32> &rays)
 {
   const int32 width = rover::settings["rover/width"].value();
   const int32 height = rover::settings["rover/height"].value();
-
   vtkm::rendering::raytracing::Camera ray_gen;
   ray_gen.SetParameters(m_camera, width, height);
   ray_gen.CreateRays(rays, this->m_coordinates.GetBounds());
   this->m_has_rays = false;
-  if(rays.NumRays == 0)
+  if (rays.NumRays == 0)
   {
     ROVER_WARN("CameraGenerator::get_rays: No rays were generated");
   }
@@ -82,12 +81,11 @@ CameraGenerator::get_rays(vtkmRayTracing::Ray<vtkm::Float64> &rays)
 {
   const int32 width = rover::settings["rover/width"].value();
   const int32 height = rover::settings["rover/height"].value();
-
   vtkm::rendering::raytracing::Camera ray_gen;
   ray_gen.SetParameters(m_camera, width, height);
   ray_gen.CreateRays(rays, this->m_coordinates.GetBounds());
   this->m_has_rays = false;
-  if(rays.NumRays == 0)
+  if (rays.NumRays == 0)
   {
     ROVER_WARN("CameraGenerator::get_rays: No rays were generated");
   }

--- a/src/libs/rover/ray_generators/camera_generator.cpp
+++ b/src/libs/rover/ray_generators/camera_generator.cpp
@@ -41,8 +41,6 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 #include <ray_generators/camera_generator.hpp>
 
-#include <vtkm/rendering/CanvasRayTracer.h>
-
 namespace rover
 {
 
@@ -68,7 +66,6 @@ CameraGenerator::get_rays(vtkmRayTracing::Ray<vtkm::Float32> &rays)
 {
   const int32 width = rover::settings["rover/width"].value();
   const int32 height = rover::settings["rover/height"].value();
-  // vtkm::rendering::CanvasRayTracer canvas(width, height);
 
   vtkm::rendering::raytracing::Camera ray_gen;
   ray_gen.SetParameters(m_camera, width, height);
@@ -85,7 +82,6 @@ CameraGenerator::get_rays(vtkmRayTracing::Ray<vtkm::Float64> &rays)
 {
   const int32 width = rover::settings["rover/width"].value();
   const int32 height = rover::settings["rover/height"].value();
-  // vtkm::rendering::CanvasRayTracer canvas(width, height);
 
   vtkm::rendering::raytracing::Camera ray_gen;
   ray_gen.SetParameters(m_camera, width, height);

--- a/src/libs/rover/ray_generators/camera_generator.cpp
+++ b/src/libs/rover/ray_generators/camera_generator.cpp
@@ -43,7 +43,8 @@
 
 #include <vtkm/rendering/CanvasRayTracer.h>
 
-namespace rover {
+namespace rover
+{
 
 CameraGenerator::CameraGenerator()
  : RayGenerator()
@@ -51,8 +52,8 @@ CameraGenerator::CameraGenerator()
 
 }
 
-CameraGenerator::CameraGenerator(const vtkmCamera &camera, const int width, const int height)
- : RayGenerator(width, height)
+CameraGenerator::CameraGenerator(const vtkmCamera &camera)
+ : RayGenerator()
 {
   m_camera = camera;
 }
@@ -65,25 +66,35 @@ CameraGenerator::~CameraGenerator()
 void
 CameraGenerator::get_rays(vtkmRayTracing::Ray<vtkm::Float32> &rays)
 {
-  vtkm::rendering::CanvasRayTracer canvas(m_width, m_height);
-  vtkm::rendering::raytracing::Camera ray_gen;
-  ray_gen.SetParameters(m_camera, m_width, m_height);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  // vtkm::rendering::CanvasRayTracer canvas(width, height);
 
+  vtkm::rendering::raytracing::Camera ray_gen;
+  ray_gen.SetParameters(m_camera, width, height);
   ray_gen.CreateRays(rays, this->m_coordinates.GetBounds());
   this->m_has_rays = false;
-  if(rays.NumRays == 0) std::cout<<"CameraGenerator Warning no rays were generated\n";
+  if(rays.NumRays == 0)
+  {
+    ROVER_WARN("CameraGenerator::get_rays: No rays were generated");
+  }
 }
 
 void
 CameraGenerator::get_rays(vtkmRayTracing::Ray<vtkm::Float64> &rays)
 {
-  vtkm::rendering::CanvasRayTracer canvas(m_width, m_height);
-  vtkm::rendering::raytracing::Camera ray_gen;
-  ray_gen.SetParameters(m_camera, m_width, m_height);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  // vtkm::rendering::CanvasRayTracer canvas(width, height);
 
+  vtkm::rendering::raytracing::Camera ray_gen;
+  ray_gen.SetParameters(m_camera, width, height);
   ray_gen.CreateRays(rays, this->m_coordinates.GetBounds());
   this->m_has_rays = false;
-  if(rays.NumRays == 0) std::cout<<"CameraGenerator Warning no rays were generated\n";
+  if(rays.NumRays == 0)
+  {
+    ROVER_WARN("CameraGenerator::get_rays: No rays were generated");
+  }
 }
 
 void

--- a/src/libs/rover/ray_generators/camera_generator.hpp
+++ b/src/libs/rover/ray_generators/camera_generator.hpp
@@ -43,6 +43,8 @@
 #define rover_camera_generator_h
 
 #include <rover_exports.h>
+#include <settings.hpp>
+#include <utils/rover_logging.hpp>
 #include <ray_generators/ray_generator.hpp>
 
 namespace rover {
@@ -51,7 +53,7 @@ class ROVER_API CameraGenerator : public RayGenerator
 {
 public:
   CameraGenerator();
-  CameraGenerator(const vtkmCamera &camera, const int width = 200, const int height = 200);
+  CameraGenerator(const vtkmCamera &camera);
   virtual ~CameraGenerator();
   virtual void get_rays(vtkmRayTracing::Ray<vtkm::Float32> &rays);
   virtual void get_rays(vtkmRayTracing::Ray<vtkm::Float64> &rays);

--- a/src/libs/rover/ray_generators/ray_generator.cpp
+++ b/src/libs/rover/ray_generators/ray_generator.cpp
@@ -40,20 +40,13 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 #include <ray_generators/ray_generator.hpp>
-namespace rover {
 
-RayGenerator::RayGenerator(int height,
-                           int width)
+namespace rover
 {
-  m_height = height;
-  m_width = width;
-  m_has_rays = true;
-}
 
 RayGenerator::RayGenerator()
-  : m_height(512),
-    m_width(512)
 {
+  m_has_rays = true;
 }
 
 RayGenerator::~RayGenerator()
@@ -67,13 +60,6 @@ RayGenerator::get_camera()
   return m_camera;
 }
 
-void
-RayGenerator::get_dims(int &height, int &width) const
-{
-  height = m_height;
-  width  = m_width;
-}
-
 bool
 RayGenerator::get_has_rays() const
 {
@@ -84,24 +70,6 @@ void
 RayGenerator::reset()
 {
   m_has_rays = true;
-}
-
-void
-RayGenerator::set_width(int width)
-{
-  m_width = width;
-}
-
-void
-RayGenerator::set_height(int height)
-{
-  m_height = height;
-}
-
-int
-RayGenerator::get_size() const
-{
-  return m_height * m_width;
 }
 
 } // naspace rover

--- a/src/libs/rover/ray_generators/ray_generator.hpp
+++ b/src/libs/rover/ray_generators/ray_generator.hpp
@@ -43,6 +43,7 @@
 #define rover_ray_generator_h
 
 #include <vtkm_typedefs.hpp>
+#include <settings.hpp>
 
 namespace rover
 {

--- a/src/libs/rover/ray_generators/ray_generator.hpp
+++ b/src/libs/rover/ray_generators/ray_generator.hpp
@@ -41,30 +41,27 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 #ifndef rover_ray_generator_h
 #define rover_ray_generator_h
+
 #include <vtkm_typedefs.hpp>
-namespace rover {
+
+namespace rover
+{
 
 class RayGenerator
 {
 public:
   RayGenerator();
-  RayGenerator(int width, int height);
   virtual ~RayGenerator();
   virtual void get_rays(vtkmRayTracing::Ray<vtkm::Float32> &rays) = 0;
   virtual void get_rays(vtkmRayTracing::Ray<vtkm::Float64> &rays) = 0;
 
   vtkmCamera& get_camera();
-  void get_dims(int &width, int &height) const;
-  int  get_size() const;
   bool get_has_rays() const;
   void reset();
-  void set_width(int width);
-  void set_height(int height);
 protected:
   vtkmCamera m_camera;
-  int  m_height;
-  int  m_width;
   bool m_has_rays;
 };
+
 }; //namespace rover
 #endif

--- a/src/libs/rover/ray_generators/visit_generator.cpp
+++ b/src/libs/rover/ray_generators/visit_generator.cpp
@@ -58,8 +58,6 @@ VisitGenerator::VisitGenerator(const VisitParams &params)
  : RayGenerator()
 {
   m_params = params;
-  assert(m_width > 0);
-  assert(m_height > 0);
 }
 
 VisitGenerator::~VisitGenerator()
@@ -75,7 +73,9 @@ VisitGenerator::gen_rays(vtkmRayTracing::Ray<T> &rays)
   double time = 0;
   ROVER_DATA_OPEN("visit_ray_gen");
 
-  const int size = m_width * m_height;
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  const int size = width * height;
 
 #if (VTKM_VERSION_MAJOR >= 2) && (VTKM_VERSION_MINOR >= 1)
     vtkm::rendering::raytracing::RayOperations::Resize(rays,
@@ -103,7 +103,7 @@ VisitGenerator::gen_rays(vtkmRayTracing::Ray<T> &rays)
 
   view_height = m_params.m_parallel_scale;
   // I think this is flipped
-  view_width = view_height * (m_height / m_width);
+  view_width = view_height * (height / width);
   if(m_params.m_perspective)
   {
     T view_dist = m_params.m_parallel_scale / tan((m_params.m_view_angle * 3.1415926535) / 360.);
@@ -133,10 +133,10 @@ VisitGenerator::gen_rays(vtkmRayTracing::Ray<T> &rays)
   far_origin = m_params.m_focus + m_params.m_far_plane * m_params.m_normal;
 
   T near_dx, near_dy, far_dx, far_dy;
-  near_dx = (2. * near_width)  / m_width;
-  near_dy = (2. * near_height) / m_height;
-  far_dx  = (2. * far_width)   / m_width;
-  far_dy  = (2. * far_height)  / m_height;
+  near_dx = (2. * near_width)  / width;
+  near_dy = (2. * near_height) / height;
+  far_dx  = (2. * far_width)   / width;
+  far_dy  = (2. * far_height)  / height;
 
   auto origin_x = rays.OriginX.WritePortal();
   auto origin_y = rays.OriginY.WritePortal();
@@ -147,8 +147,8 @@ VisitGenerator::gen_rays(vtkmRayTracing::Ray<T> &rays)
   auto dir_z = rays.DirZ.WritePortal();
 
   auto pixel_id = rays.PixelIdx.WritePortal();
-  const int x_size = m_width;
-  const int y_size = m_height;
+  const int x_size = width;
+  const int y_size = height;
 
   const T x_factor = - (2. * m_params.m_image_pan[0] * m_params.m_image_zoom + 1.);
   const T x_start  = x_factor * near_width + near_dx / 2.;

--- a/src/libs/rover/ray_generators/visit_generator.cpp
+++ b/src/libs/rover/ray_generators/visit_generator.cpp
@@ -99,11 +99,11 @@ VisitGenerator::gen_rays(vtkmRayTracing::Ray<T> &rays)
                  - m_params.m_view_up[1] * m_params.m_normal[0];
 
   T near_height, view_height, far_height;
-  T near_width, view_width, far_width;;
+  T near_width, view_width, far_width;
 
   view_height = m_params.m_parallel_scale;
   // I think this is flipped
-  view_width = view_height * (height / width);
+  view_width = view_height * static_cast<float>(height) / static_cast<float>(width);
   if(m_params.m_perspective)
   {
     T view_dist = m_params.m_parallel_scale / tan((m_params.m_view_angle * 3.1415926535) / 360.);

--- a/src/libs/rover/ray_generators/visit_generator.cpp
+++ b/src/libs/rover/ray_generators/visit_generator.cpp
@@ -72,7 +72,6 @@ VisitGenerator::gen_rays(vtkmRayTracing::Ray<T> &rays)
   vtkmTimer timer;
   double time = 0;
   ROVER_DATA_OPEN("visit_ray_gen");
-
   const int32 width = rover::settings["rover/width"].value();
   const int32 height = rover::settings["rover/height"].value();
   const int size = width * height;

--- a/src/libs/rover/ray_generators/visit_generator.hpp
+++ b/src/libs/rover/ray_generators/visit_generator.hpp
@@ -43,9 +43,11 @@
 #define rover_visit_generator_h
 
 #include <rover_exports.h>
+#include <settings.hpp>
 #include <ray_generators/ray_generator.hpp>
 
-namespace rover {
+namespace rover
+{
 
 class ROVER_API VisitGenerator : public RayGenerator
 {
@@ -92,7 +94,6 @@ public:
       std::cout<<"zoom          : "<<m_image_zoom<<"\n";
       std::cout<<"perspective   : "<<m_perspective<<"\n";
     }
-
 
   };
 

--- a/src/libs/rover/rover.cpp
+++ b/src/libs/rover/rover.cpp
@@ -224,23 +224,6 @@ void
 Rover::update_ray_generator()
 {
   m_ray_generator.set_camera(m_camera);
-
-  int32 width;
-  int32 height;
-
-  if (rover::settings.has_path("rover/width"))
-  {
-    width = rover::settings["rover/width"].value();
-  }
-
-  if (rover::settings.has_path("rover/height"))
-  {
-    height = rover::settings["rover/height"].value();
-  }
-
-  m_ray_generator.set_width(width);
-  m_ray_generator.set_height(height);
-
   m_scheduler->set_ray_generator(&m_ray_generator);
 }
 

--- a/src/libs/rover/scheduler.cpp
+++ b/src/libs/rover/scheduler.cpp
@@ -5,6 +5,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 
+#include "settings.hpp"
 #include <assert.h>
 #include <fstream>
 #include <vtkh/compositing/PartialCompositor.hpp>
@@ -214,17 +215,13 @@ Scheduler<FloatType>::set_global_bounds()
 
 template<typename FloatType>
 void
-Scheduler<FloatType>::add_partial(vtkmRayTracing::PartialComposite<FloatType> &partial,
-                                  int width,
-                                  int height)
+Scheduler<FloatType>::add_partial(vtkmRayTracing::PartialComposite<FloatType> &partial)
 {
   PartialImage<FloatType> partial_image;
   partial_image.m_pixel_ids = partial.PixelIds;
   partial_image.m_distances = partial.Distances;
   partial_image.m_buffer = partial.Buffer;
   partial_image.m_intensities = partial.Intensities;
-  partial_image.m_width = width;
-  partial_image.m_height = height;
   m_partial_images.push_back(partial_image);
 }
 
@@ -272,6 +269,8 @@ Scheduler<FloatType>::composite()
   }
 #endif
 
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
   const std::string emission = rover::settings["rover/emission"].as_string();
   if ("" != emission)
   {
@@ -281,8 +280,6 @@ Scheduler<FloatType>::composite()
       compositor.set_comm_handle(MPI_Comm_c2f(m_comm_handle));
 #endif
     const int num_partials = m_partial_images.size();
-    int width = m_partial_images[0].m_width;
-    int height = m_partial_images[0].m_height;
     std::vector<std::vector<vtkh::EmissionPartial<FloatType>>> partials;
     partials.resize(num_partials);
     for(int i = 0; i < num_partials; ++i)
@@ -296,7 +293,7 @@ Scheduler<FloatType>::composite()
     if(rank == 0)
     {
       // data only valid on rank = 0
-      p_result.store(result,m_background, width, height);
+      p_result.store(result, m_background);
     }
 
     m_result = p_result;
@@ -310,8 +307,6 @@ Scheduler<FloatType>::composite()
     compositor.set_comm_handle(MPI_Comm_c2f(m_comm_handle));
 #endif
     const int num_partials = m_partial_images.size();
-    int width = m_partial_images[0].m_width;
-    int height = m_partial_images[0].m_height;
     std::vector<std::vector<vtkh::AbsorptionPartial<FloatType>>> partials;
     partials.resize(num_partials);
     for(int i = 0; i < num_partials; ++i)
@@ -325,7 +320,7 @@ Scheduler<FloatType>::composite()
     if(rank == 0)
     {
       // data only valid on rank = 0
-      p_result.store(result,m_background, width, height);
+      p_result.store(result, m_background);
     }
 
     m_result = p_result;
@@ -359,14 +354,8 @@ Scheduler<FloatType>::trace_rays()
   // TODO while (m_generator.has_rays())
   ROVER_INFO("Tracing rays");
 
-  int width;
-  int height;
-  m_ray_generator->get_dims(width, height);
-
-  if (width <= 0 || height <= 0)
-  {
-    ROVER_ERROR("Error: trace_rays failed due to non-positive output dimensions: " << width << "x" << height );
-  }
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
 
   //
   // ensure that the render settings are set
@@ -434,7 +423,7 @@ Scheduler<FloatType>::trace_rays()
     //
     for(size_t p = 0; p < partials.size(); ++p)
     {
-      add_partial(partials[p], width, height);
+      add_partial(partials[p]);
     }
 
     timer.Start();
@@ -458,8 +447,6 @@ Scheduler<FloatType>::trace_rays()
   if(num_domains == 0 || m_partial_images.size() == 0)
   {
     PartialImage<FloatType> partial_image;
-    partial_image.m_width = width;
-    partial_image.m_height = height;
     partial_image.m_buffer =
       vtkm::rendering::raytracing::ChannelBuffer<FloatType>(num_channels, 0);
 
@@ -523,15 +510,8 @@ Scheduler<FloatType>::get_result(Image<vtkm::Float64> &image)
 template<typename FloatType>
 void Scheduler<FloatType>::save_result(std::string file_name)
 {
-  int width;
-  int height;
-  m_ray_generator->get_dims(width, height);
-
-  if (width <= 0 || height <= 0)
-  {
-    ROVER_ERROR("Error: save_result failed due to non-positive output dimensions: " << width << "x" << height );
-  }
-
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
   ROVER_INFO("Saving .png file with output size " << width << "x" << height);
   ascent::PNGEncoder encoder;
 
@@ -547,6 +527,8 @@ void Scheduler<FloatType>::save_result(std::string file_name)
     FloatType * buffer
       = get_vtkm_ptr(m_result.get_intensity(i));
 
+    const int32 width = rover::settings["rover/width"].value();
+    const int32 height = rover::settings["rover/height"].value();
     encoder.EncodeChannel(buffer, width, height);
     encoder.Save(sstream.str());
   }
@@ -575,15 +557,8 @@ Scheduler<FloatType>::save_result(std::string file_name,
                                   float max_val,
                                   bool log_scale)
 {
-  int width;
-  int height;
-  m_ray_generator->get_dims(width, height);
-
-  if (width <= 0 || height <= 0)
-  {
-    ROVER_ERROR("Error: save_result failed due to non-positive output dimensions: " << width << "x" << height );
-  }
-
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
   ROVER_INFO("Saving .png file with output size " << width << "x" << height);
   ascent::PNGEncoder encoder;
 
@@ -612,15 +587,8 @@ Scheduler<FloatType>::save_result(std::string file_name,
 template<typename FloatType>
 void Scheduler<FloatType>::save_bov(std::string file_name)
 {
-  int width;
-  int height;
-  m_ray_generator->get_dims(width, height);
-
-  if (width <= 0 || height <= 0)
-  {
-    ROVER_ERROR("Error: save_bov failed due to non-positive output dimensions: " << width << "x" << height );
-  }
-
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
   ROVER_INFO("Saving bov file with output size " << width << "x" << height);
   ascent::PNGEncoder encoder;
   const int size = height * width;
@@ -648,21 +616,9 @@ template<typename FloatType>
 void
 Scheduler<FloatType>::to_blueprint(Node &data)
 {
-  int width;
-  int height;
-  m_ray_generator->get_dims(width, height);
-
-  if (width <= 0 || height <= 0)
-  {
-    ROVER_ERROR("Error: to_blueprint failed due to non-positive output dimensions: " << width << "x" << height );
-  }
-
+  int32 width = rover::settings["rover/width"].value();
+  int32 height = rover::settings["rover/height"].value();
   ROVER_INFO("Saving blueprint file with output size " << width << "x" << height);
-
-  const std::string topo_name = "image_topo";
-  const std::string coord_name = "image_coords";
-
-  const int num_channels = m_result.get_num_channels();
 
   // TODO: Plumb the other "state/" info down out of *_rover_filters.cpp
   Node &xray_view = data["state/xray_view"];
@@ -679,16 +635,21 @@ Scheduler<FloatType>::to_blueprint(Node &data)
   xray_view["xpan"] = xy_pan[0];
   xray_view["ypan"] = xy_pan[1];
 
-  Node &n_coords = data["coordsets/" + coord_name];
-  n_coords["type"] = "rectilinear";
-  
-  n_coords["values/x"].set(DataType::float32(width + 1));
-  n_coords["values/y"].set(DataType::float32(height + 1));
-  n_coords["values/z"].set(DataType::float32(num_channels + 1));
+  Node &xray_query = data["xray_query"];
+  xray_query.set(rover::settings["rover"]);
 
-  float32_array x_coords = n_coords["values/x"].value();
-  float32_array y_coords = n_coords["values/y"].value();
-  float32_array z_coords = n_coords["values/z"].value();
+  const int num_channels = m_result.get_num_channels();
+  const std::string coord_name = "image_coords";
+  Node &coordsets = data["coordsets"][coord_name];
+  coordsets["type"] = "rectilinear";
+  
+  coordsets["values/x"].set(DataType::float32(width + 1));
+  coordsets["values/y"].set(DataType::float32(height + 1));
+  coordsets["values/z"].set(DataType::float32(num_channels + 1));
+
+  float32_array x_coords = coordsets["values/x"].value();
+  float32_array y_coords = coordsets["values/y"].value();
+  float32_array z_coords = coordsets["values/z"].value();
 
   for (int i = 0; i <= width; i++)
   {
@@ -705,15 +666,16 @@ Scheduler<FloatType>::to_blueprint(Node &data)
     z_coords[i] = i;
   }
 
-  n_coords["labels/x"] = "width";
-  n_coords["labels/y"] = "height";
-  n_coords["labels/z"] = "energy_group";
+  coordsets["labels/x"] = "width";
+  coordsets["labels/y"] = "height";
+  coordsets["labels/z"] = "energy_group";
 
-  n_coords["units/x"] = "pixels";
-  n_coords["units/y"] = "pixels";
-  n_coords["units/z"] = "bins";
+  coordsets["units/x"] = "pixels";
+  coordsets["units/y"] = "pixels";
+  coordsets["units/z"] = "bins";
 
-  Node &n_topo = data["topologies/" + topo_name];
+  const std::string topo_name = "image_topo";
+  Node &n_topo = data["topologies"][topo_name];
   n_topo["coordset"] = coord_name;
   n_topo["type"] = "rectilinear";
 

--- a/src/libs/rover/scheduler.cpp
+++ b/src/libs/rover/scheduler.cpp
@@ -33,7 +33,7 @@ namespace rover
 template<typename FloatType>
 Scheduler<FloatType>::Scheduler()
 {
-  m_ray_generator = NULL;
+  m_ray_generator = nullptr;
 }
 
 template<typename FloatType>
@@ -269,8 +269,6 @@ Scheduler<FloatType>::composite()
   }
 #endif
 
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
   const std::string emission = rover::settings["rover/emission"].as_string();
   if ("" != emission)
   {
@@ -353,9 +351,6 @@ Scheduler<FloatType>::trace_rays()
   m_ray_generator->reset();
   // TODO while (m_generator.has_rays())
   ROVER_INFO("Tracing rays");
-
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
 
   //
   // ensure that the render settings are set
@@ -510,9 +505,7 @@ Scheduler<FloatType>::get_result(Image<vtkm::Float64> &image)
 template<typename FloatType>
 void Scheduler<FloatType>::save_result(std::string file_name)
 {
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  ROVER_INFO("Saving .png file with output size " << width << "x" << height);
+  ROVER_INFO("Saving .png file with output size " << m_width << "x" << m_height);
   ascent::PNGEncoder encoder;
 
   // if(m_render_settings.m_render_mode == energy) // removing volume renderer
@@ -527,9 +520,7 @@ void Scheduler<FloatType>::save_result(std::string file_name)
     FloatType * buffer
       = get_vtkm_ptr(m_result.get_intensity(i));
 
-    const int32 width = rover::settings["rover/width"].value();
-    const int32 height = rover::settings["rover/height"].value();
-    encoder.EncodeChannel(buffer, width, height);
+    encoder.EncodeChannel(buffer, m_width, m_height);
     encoder.Save(sstream.str());
   }
 
@@ -557,9 +548,7 @@ Scheduler<FloatType>::save_result(std::string file_name,
                                   float max_val,
                                   bool log_scale)
 {
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  ROVER_INFO("Saving .png file with output size " << width << "x" << height);
+  ROVER_INFO("Saving .png file with output size " << m_width << "x" << m_height);
   ascent::PNGEncoder encoder;
 
 #if 0 // removing volume renderer
@@ -579,7 +568,7 @@ Scheduler<FloatType>::save_result(std::string file_name,
     FloatType * buffer
       = get_vtkm_ptr(m_result.get_intensity(i));
 
-    encoder.EncodeChannel(buffer, width, height);
+    encoder.EncodeChannel(buffer, m_width, m_height);
     encoder.Save(sstream.str());
   }
 }
@@ -587,11 +576,9 @@ Scheduler<FloatType>::save_result(std::string file_name,
 template<typename FloatType>
 void Scheduler<FloatType>::save_bov(std::string file_name)
 {
-  const int32 width = rover::settings["rover/width"].value();
-  const int32 height = rover::settings["rover/height"].value();
-  ROVER_INFO("Saving bov file with output size " << width << "x" << height);
+  ROVER_INFO("Saving bov file with output size " << m_width << "x" << m_height);
   ascent::PNGEncoder encoder;
-  const int size = height * width;
+  const int size = m_height * m_width;
 
   // if(m_render_settings.m_render_mode == energy) // removing volume renderer
   // {
@@ -616,9 +603,7 @@ template<typename FloatType>
 void
 Scheduler<FloatType>::to_blueprint(Node &data)
 {
-  int32 width = rover::settings["rover/width"].value();
-  int32 height = rover::settings["rover/height"].value();
-  ROVER_INFO("Saving blueprint file with output size " << width << "x" << height);
+  ROVER_INFO("Saving blueprint file with output size " << m_width << "x" << m_height);
 
   // TODO: Plumb the other "state/" info down out of *_rover_filters.cpp
   Node &xray_view = data["state/xray_view"];
@@ -640,23 +625,23 @@ Scheduler<FloatType>::to_blueprint(Node &data)
 
   const int num_channels = m_result.get_num_channels();
   const std::string coord_name = "image_coords";
-  Node &coordsets = data["coordsets"][coord_name];
-  coordsets["type"] = "rectilinear";
+  Node &n_coords = data["coordsets"][coord_name];
+  n_coords["type"] = "rectilinear";
   
-  coordsets["values/x"].set(DataType::float32(width + 1));
-  coordsets["values/y"].set(DataType::float32(height + 1));
-  coordsets["values/z"].set(DataType::float32(num_channels + 1));
+  n_coords["values/x"].set(DataType::float32(m_width + 1));
+  n_coords["values/y"].set(DataType::float32(m_height + 1));
+  n_coords["values/z"].set(DataType::float32(num_channels + 1));
 
-  float32_array x_coords = coordsets["values/x"].value();
-  float32_array y_coords = coordsets["values/y"].value();
-  float32_array z_coords = coordsets["values/z"].value();
+  float32_array x_coords = n_coords["values/x"].value();
+  float32_array y_coords = n_coords["values/y"].value();
+  float32_array z_coords = n_coords["values/z"].value();
 
-  for (int i = 0; i <= width; i++)
+  for (int i = 0; i <= m_width; i++)
   {
     x_coords[i] = i;
   }
 
-  for (int i = 0; i <= height; i++)
+  for (int i = 0; i <= m_height; i++)
   {
     y_coords[i] = i;
   }
@@ -666,13 +651,13 @@ Scheduler<FloatType>::to_blueprint(Node &data)
     z_coords[i] = i;
   }
 
-  coordsets["labels/x"] = "width";
-  coordsets["labels/y"] = "height";
-  coordsets["labels/z"] = "energy_group";
+  n_coords["labels/x"] = "width";
+  n_coords["labels/y"] = "height";
+  n_coords["labels/z"] = "energy_group";
 
-  coordsets["units/x"] = "pixels";
-  coordsets["units/y"] = "pixels";
-  coordsets["units/z"] = "bins";
+  n_coords["units/x"] = "pixels";
+  n_coords["units/y"] = "pixels";
+  n_coords["units/z"] = "bins";
 
   const std::string topo_name = "image_topo";
   Node &n_topo = data["topologies"][topo_name];
@@ -700,8 +685,8 @@ Scheduler<FloatType>::to_blueprint(Node &data)
   intensities["strides"].set(DataType::int64(3));
   int64_array strides = intensities["strides"].value();
   strides[0] = 1;
-  strides[1] = width;
-  strides[2] = width * height;
+  strides[1] = m_width;
+  strides[2] = m_width * m_height;
 
   // Optical Depth
   Node &optical_depth = data["fields/optical_depth"];

--- a/src/libs/rover/scheduler.cpp
+++ b/src/libs/rover/scheduler.cpp
@@ -505,11 +505,14 @@ Scheduler<FloatType>::get_result(Image<vtkm::Float64> &image)
 template<typename FloatType>
 void Scheduler<FloatType>::save_result(std::string file_name)
 {
-  ROVER_INFO("Saving .png file with output size " << m_width << "x" << m_height);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  ROVER_INFO("Saving .png file with output size " << width << "x" << height);
   ascent::PNGEncoder encoder;
 
   // if(m_render_settings.m_render_mode == energy) // removing volume renderer
   // {
+
   const int num_channels = m_result.get_num_channels();
   ROVER_INFO("Saving "<<num_channels<<" channels ");
   for(int i = 0; i < num_channels; ++i)
@@ -520,7 +523,7 @@ void Scheduler<FloatType>::save_result(std::string file_name)
     FloatType * buffer
       = get_vtkm_ptr(m_result.get_intensity(i));
 
-    encoder.EncodeChannel(buffer, m_width, m_height);
+    encoder.EncodeChannel(buffer, width, height);
     encoder.Save(sstream.str());
   }
 
@@ -548,7 +551,9 @@ Scheduler<FloatType>::save_result(std::string file_name,
                                   float max_val,
                                   bool log_scale)
 {
-  ROVER_INFO("Saving .png file with output size " << m_width << "x" << m_height);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  ROVER_INFO("Saving .png file with output size " << width << "x" << height);
   ascent::PNGEncoder encoder;
 
 #if 0 // removing volume renderer
@@ -568,7 +573,7 @@ Scheduler<FloatType>::save_result(std::string file_name,
     FloatType * buffer
       = get_vtkm_ptr(m_result.get_intensity(i));
 
-    encoder.EncodeChannel(buffer, m_width, m_height);
+    encoder.EncodeChannel(buffer, width, height);
     encoder.Save(sstream.str());
   }
 }
@@ -576,9 +581,12 @@ Scheduler<FloatType>::save_result(std::string file_name,
 template<typename FloatType>
 void Scheduler<FloatType>::save_bov(std::string file_name)
 {
-  ROVER_INFO("Saving bov file with output size " << m_width << "x" << m_height);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  ROVER_INFO("Saving bov file with output size " << width << "x" << height);
+
   ascent::PNGEncoder encoder;
-  const int size = m_height * m_width;
+  const int size = height * width;
 
   // if(m_render_settings.m_render_mode == energy) // removing volume renderer
   // {
@@ -603,7 +611,9 @@ template<typename FloatType>
 void
 Scheduler<FloatType>::to_blueprint(Node &data)
 {
-  ROVER_INFO("Saving blueprint file with output size " << m_width << "x" << m_height);
+  const int32 width = rover::settings["rover/width"].value();
+  const int32 height = rover::settings["rover/height"].value();
+  ROVER_INFO("Saving blueprint file with output size " << width << "x" << height);
 
   // TODO: Plumb the other "state/" info down out of *_rover_filters.cpp
   Node &xray_view = data["state/xray_view"];
@@ -628,20 +638,20 @@ Scheduler<FloatType>::to_blueprint(Node &data)
   Node &n_coords = data["coordsets"][coord_name];
   n_coords["type"] = "rectilinear";
   
-  n_coords["values/x"].set(DataType::float32(m_width + 1));
-  n_coords["values/y"].set(DataType::float32(m_height + 1));
+  n_coords["values/x"].set(DataType::float32(width + 1));
+  n_coords["values/y"].set(DataType::float32(height + 1));
   n_coords["values/z"].set(DataType::float32(num_channels + 1));
 
   float32_array x_coords = n_coords["values/x"].value();
   float32_array y_coords = n_coords["values/y"].value();
   float32_array z_coords = n_coords["values/z"].value();
 
-  for (int i = 0; i <= m_width; i++)
+  for (int i = 0; i <= width; i++)
   {
     x_coords[i] = i;
   }
 
-  for (int i = 0; i <= m_height; i++)
+  for (int i = 0; i <= height; i++)
   {
     y_coords[i] = i;
   }
@@ -685,8 +695,8 @@ Scheduler<FloatType>::to_blueprint(Node &data)
   intensities["strides"].set(DataType::int64(3));
   int64_array strides = intensities["strides"].value();
   strides[0] = 1;
-  strides[1] = m_width;
-  strides[2] = m_width * m_height;
+  strides[1] = width;
+  strides[2] = width * height;
 
   // Optical Depth
   Node &optical_depth = data["fields/optical_depth"];

--- a/src/libs/rover/scheduler.hpp
+++ b/src/libs/rover/scheduler.hpp
@@ -54,7 +54,7 @@ protected:
   Image<FloatType>                          m_result;
   std::vector<PartialImage<FloatType>>      m_partial_images;
 
-  void add_partial(vtkmRayTracing::PartialComposite<FloatType> &partial, int width, int height);
+  void add_partial(vtkmRayTracing::PartialComposite<FloatType> &partial);
 private:
 
 };

--- a/src/libs/rover/scheduler.hpp
+++ b/src/libs/rover/scheduler.hpp
@@ -47,16 +47,14 @@ public:
   virtual void get_result(Image<vtkm::Float32> &image) override;
   virtual void get_result(Image<vtkm::Float64> &image) override;
 protected:
+  Image<FloatType>                          m_result;
+  std::vector<PartialImage<FloatType>>      m_partial_images;
+
   void composite();
   void set_global_scalar_range();
   void set_global_bounds();
   int  get_global_channels();
-  Image<FloatType>                          m_result;
-  std::vector<PartialImage<FloatType>>      m_partial_images;
-
   void add_partial(vtkmRayTracing::PartialComposite<FloatType> &partial);
-private:
-
 };
 
 }; // namespace rover

--- a/src/libs/rover/scheduler_base.cpp
+++ b/src/libs/rover/scheduler_base.cpp
@@ -10,6 +10,8 @@ namespace rover {
 
 SchedulerBase::SchedulerBase()
 {
+  m_width = rover::settings["rover/width"].value();
+  m_height = rover::settings["rover/height"].value();
 }
 
 SchedulerBase::~SchedulerBase()

--- a/src/libs/rover/scheduler_base.cpp
+++ b/src/libs/rover/scheduler_base.cpp
@@ -10,8 +10,7 @@ namespace rover {
 
 SchedulerBase::SchedulerBase()
 {
-  m_width = rover::settings["rover/width"].value();
-  m_height = rover::settings["rover/height"].value();
+
 }
 
 SchedulerBase::~SchedulerBase()

--- a/src/libs/rover/scheduler_base.hpp
+++ b/src/libs/rover/scheduler_base.hpp
@@ -71,8 +71,8 @@ public:
   virtual void get_result(Image<vtkm::Float32> &image) = 0;
   virtual void get_result(Image<vtkm::Float64> &image) = 0;
 protected:
-  int                                       m_width;
-  int                                       m_height;
+  int32                                     m_width;
+  int32                                     m_height;
   std::vector<Domain>                       m_domains;
   RayGenerator                             *m_ray_generator;
   std::vector<vtkm::Float64>                m_background;

--- a/src/libs/rover/scheduler_base.hpp
+++ b/src/libs/rover/scheduler_base.hpp
@@ -71,6 +71,8 @@ public:
   virtual void get_result(Image<vtkm::Float32> &image) = 0;
   virtual void get_result(Image<vtkm::Float64> &image) = 0;
 protected:
+  int                                       m_width;
+  int                                       m_height;
   std::vector<Domain>                       m_domains;
   RayGenerator                             *m_ray_generator;
   std::vector<vtkm::Float64>                m_background;

--- a/src/libs/rover/scheduler_base.hpp
+++ b/src/libs/rover/scheduler_base.hpp
@@ -71,8 +71,6 @@ public:
   virtual void get_result(Image<vtkm::Float32> &image) = 0;
   virtual void get_result(Image<vtkm::Float64> &image) = 0;
 protected:
-  int32                                     m_width;
-  int32                                     m_height;
   std::vector<Domain>                       m_domains;
   RayGenerator                             *m_ray_generator;
   std::vector<vtkm::Float64>                m_background;


### PR DESCRIPTION
Addresses bullets in https://github.com/Alpine-DAV/ascent/issues/1513

- Removes instances of passing/storing width and height, in favor of querying the global settings node wherever we need those values.
- Dumps all of the options used by Rover into the output node under "state/xray_query".