### PR TITLE
Remove Rover tests box clip workaround

### DIFF
--- a/.github/workflows/build_ascent_win.yml
+++ b/.github/workflows/build_ascent_win.yml
@@ -41,6 +41,19 @@ jobs:
       run: |
         echo "**** Ascent Unit Tests"
         cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Release --target RUN_TESTS
+    
+    - name: Run Ascent Unit Tests
+      run: |
+        echo "**** Ascent Unit Tests"
+        cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Release --target RUN_TESTS
+
+    - name: Upload Ascent Unit Test Artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: build/tests/_output/
+        retention-days: 7
     # NOT READY FOR THIS ON WINDOWS YET
     # - name: Create Unit Test Report
     #   if: always()

--- a/.github/workflows/build_ascent_win.yml
+++ b/.github/workflows/build_ascent_win.yml
@@ -41,14 +41,7 @@ jobs:
       run: |
         echo "**** Ascent Unit Tests"
         cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Release --target RUN_TESTS
-    
-    - name: Run Ascent Unit Tests
-      run: |
-        echo "**** Ascent Unit Tests"
-        cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Release --target RUN_TESTS
-
     - name: Upload Ascent Unit Test Artifacts
-      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-results

--- a/.github/workflows/build_ascent_win.yml
+++ b/.github/workflows/build_ascent_win.yml
@@ -42,6 +42,7 @@ jobs:
         echo "**** Ascent Unit Tests"
         cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Release --target RUN_TESTS
     - name: Upload Ascent Unit Test Artifacts
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-results

--- a/src/libs/ascent/runtimes/flow_filters/ascent_runtime_rover_filters.cpp
+++ b/src/libs/ascent/runtimes/flow_filters/ascent_runtime_rover_filters.cpp
@@ -221,20 +221,19 @@ RoverXRay::verify_params(const conduit::Node &params,
     }
   }
 
-  // TODO: Remove this once issue #1559 is fixed
-  if (n_rover.has_child("enable_imaging_planes"))
+  if (n_rover.has_child("enable_rays_mesh"))
   {
-    if (!n_rover["enable_imaging_planes"].dtype().is_string())
+    if (!n_rover["enable_rays_mesh"].dtype().is_string())
     {
-      info["errors"].append() = "Optional bool string parameter 'rover/enable_imaging_planes' is not a string";
+      info["errors"].append() = "Optional bool string parameter 'rover/enable_rays_mesh' is not a string";
       res = false;
     }
-    else // (n_rover["enable_imaging_planes"].dtype().is_string())
+    else // (n_rover["enable_rays_mesh"].dtype().is_string())
     {
-      const std::string enable_imaging_planes = n_rover["enable_imaging_planes"].as_string();
-      if ("true" != enable_imaging_planes && "false" != enable_imaging_planes)
+      const std::string enable_rays_mesh = n_rover["enable_rays_mesh"].as_string();
+      if ("true" != enable_rays_mesh && "false" != enable_rays_mesh)
       {
-        info["errors"].append() = "Optional bool string parameter 'rover/enable_imaging_planes' must be 'true' or 'false'";
+        info["errors"].append() = "Optional bool string parameter 'rover/enable_rays_mesh' must be 'true' or 'false'";
         res = false;
       }
     }
@@ -420,7 +419,7 @@ RoverXRay::verify_params(const conduit::Node &params,
     "rover/background_intensity",
     "rover/divide_emis_by_absorb",
     "rover/emission",
-    "rover/enable_imaging_planes", // TODO: Remove this once #1559 is fixed
+    "rover/enable_rays_mesh",
     "rover/filename",
     "rover/height",
     "rover/output_type",

--- a/src/libs/rover/rover.cpp
+++ b/src/libs/rover/rover.cpp
@@ -32,7 +32,7 @@ Rover::Rover()
   // Settings
   rover::settings["background_intensity"] = 0.0f;
   rover::settings["divide_emis_by_absorb"] = "false";
-  rover::settings["enable_imaging_planes"] = "true"; // TODO: Remove this once issue #1559 is fixed
+  rover::settings["enable_rays_mesh"] = "false";
   rover::settings["height"] = 200;
   rover::settings["precision"] = "single";
   rover::settings["width"] = 200;

--- a/src/libs/rover/typed_scheduler.cpp
+++ b/src/libs/rover/typed_scheduler.cpp
@@ -1040,72 +1040,73 @@ TypedScheduler<FloatType>::to_blueprint(Node &data)
   optical_depth_spatial.set(optical_depth);
   optical_depth_spatial["topology"] = "spatial_topo";
 
-  // TODO: Remove this once issue #1559 is fixed
-  const bool enable_imaging_planes = rover::settings["enable_imaging_planes"].as_string() == "true";
-  if (enable_imaging_planes)
+  //
+  // Near plane mesh
+  //
+
+  write_blueprint_imaging_plane(data,
+                                "near_plane",
+                                near_width,
+                                near_height,
+                                center_near,
+                                left,
+                                up,
+                                llc_near,
+                                lrc_near,
+                                ulc_near,
+                                urc_near);
+
+  //
+  // View plane mesh
+  //
+
+  write_blueprint_imaging_plane(data,
+                                "view_plane",
+                                view_width,
+                                view_height,
+                                center_view,
+                                left,
+                                up,
+                                llc_view,
+                                lrc_view,
+                                ulc_view,
+                                urc_view);
+
+  //
+  // Far plane mesh
+  //
+
+  write_blueprint_imaging_plane(data,
+                                "far_plane",
+                                far_width,
+                                far_height,
+                                center_far,
+                                left,
+                                up,
+                                llc_far,
+                                lrc_far,
+                                ulc_far,
+                                urc_far);
+
+  //
+  // Ray meshes
+  //
+
+  write_blueprint_ray_corners_mesh(data,
+                                   llc_near,
+                                   llc_far,
+                                   lrc_near,
+                                   lrc_far,
+                                   urc_near,
+                                   urc_far,
+                                   ulc_near,
+                                   ulc_far);
+
+  // This mesh can be very large depending on the image width and height, and it won't
+  // always be useful. We only include it in the output if the user explicitly asks for it.
+  const bool enable_rays_mesh = rover::settings["enable_rays_mesh"].as_string() == "true";
+  if (enable_rays_mesh)
   {
-    //
-    // Near plane mesh
-    //
-
-    write_blueprint_imaging_plane(data,
-                                  "near_plane",
-                                  near_width,
-                                  near_height,
-                                  center_near,
-                                  left,
-                                  up,
-                                  llc_near,
-                                  lrc_near,
-                                  ulc_near,
-                                  urc_near);
-
-    //
-    // View plane mesh
-    //
-
-    write_blueprint_imaging_plane(data,
-                                  "view_plane",
-                                  view_width,
-                                  view_height,
-                                  center_view,
-                                  left,
-                                  up,
-                                  llc_view,
-                                  lrc_view,
-                                  ulc_view,
-                                  urc_view);
-
-    //
-    // Far plane mesh
-    //
-
-    write_blueprint_imaging_plane(data,
-                                  "far_plane",
-                                  far_width,
-                                  far_height,
-                                  center_far,
-                                  left,
-                                  up,
-                                  llc_far,
-                                  lrc_far,
-                                  ulc_far,
-                                  urc_far);
-
-    //
-    // Ray meshes
-    //
-
-    write_blueprint_ray_corners_mesh(data,
-                                    llc_near,
-                                    llc_far,
-                                    lrc_near,
-                                    lrc_far,
-                                    urc_near,
-                                    urc_far,
-                                    ulc_near,
-                                    ulc_far);
-
     write_blueprint_rays_mesh(data,
                               image_width,
                               image_height,

--- a/src/tests/ascent/t_ascent_rover.cpp
+++ b/src/tests/ascent/t_ascent_rover.cpp
@@ -50,23 +50,9 @@ execute_ascent(const Node& data,
 void
 render_blueprint(const string &field_name,
                  const string &output_path,
-                 const Node &data,
-                 const double detector_width)
+                 const Node &data)
 {
     // Define Ascent actions
-
-    // TODO: Remove this once issue #1559 is fixed
-    Node pipelines;
-    Node &pl = pipelines["pl1"];
-    pl["f1/type"] = "clip";
-    pl["f1/params/topology"] = "image_topo";
-    pl["f1/params/invert"] = "true";
-    pl["f1/params/box/min/x"] = 0.0;
-    pl["f1/params/box/min/y"] = 0.0;
-    pl["f1/params/box/min/z"] = 0.0;
-    pl["f1/params/box/max/x"] = detector_width;
-    pl["f1/params/box/max/y"] = detector_width;
-    pl["f1/params/box/max/z"] = 0.0;
 
     Node scenes;
     scenes["s1/plots/p1/type"] = "pseudocolor";
@@ -77,15 +63,9 @@ render_blueprint(const string &field_name,
     if (field_name.find("spatial") != std::string::npos)
     {
         scenes["s1/renders/r1/camera/azimuth"] = 45.0;
-        scenes["s1/plots/p1/pipeline"] = "pl1"; // TODO: Remove this once issue #1559 is fixed
     }
 
     Node actions;
-
-    // TODO: Remove this once issue #1559 is fixed
-    Node &add_pipelines = actions.append();
-    add_pipelines["action"] = "add_pipelines";
-    add_pipelines["pipelines"] = pipelines;
 
     Node &add_plots = actions.append();
     add_plots["action"] = "add_scenes";
@@ -102,20 +82,20 @@ render_all_fields(const Node &data,
 {
     // This is here to help identify which ascent execute is throwing an error
     ASCENT_INFO("Executing render_all_fields\n");
-
-    // TODO: Remove this once issue #1559 is fixed
-    const Node &xray_data = data["domain_000000/state/xray_data"];
-    const double detector_width = xray_data["detector_width"].to_double();
     
-    const std::vector<std::string> fields {"intensities", 
-                                           "optical_depth",
-                                           "intensities_spatial",
-                                           "optical_depth_spatial"
-                                          };
-    for (auto field : fields)
+    const std::vector<std::string> fields {
+        "intensities",
+        "optical_depth",
+        "intensities_spatial",
+        "optical_depth_spatial"
+    };
+
+    // TODO: Investigate whether we gain any performance by rendering all of these fields with
+    // a single set of actions
+    for (const auto& field : fields)
     {
         std::string full_output_path = output_path + "_" + field;
-        render_blueprint(field, full_output_path, data, detector_width);
+        render_blueprint(field, full_output_path, data);
         EXPECT_TRUE(check_test_image(full_output_path, 0.01f, cycle));
     }
 }
@@ -134,7 +114,8 @@ load_and_verify_ascent_data(Node &baseline_data,
                             const std::string filename)
 {
     Node verify_info;
-    const std::string baseline_path = conduit::utils::join_file_path(std::string(ASCENT_T_DATA_DIR), filename);
+    const std::string baseline_path = conduit::utils::join_file_path(std::string(ASCENT_T_DATA_DIR),
+                                                                     filename);
     conduit::relay::io::blueprint::load_mesh(baseline_path, baseline_data);
     EXPECT_TRUE(conduit::blueprint::mesh::verify(baseline_data, verify_info));
 }
@@ -204,7 +185,6 @@ TEST(ascent_rover, test_xray_blueprint_braid)
     extracts["e1/params/rover/filename"] = query_path;
     extracts["e1/params/rover/output_type"] = "yaml";
     extracts["e1/params/rover/precision"] = "double";
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
 
     Node actions;
     Node &add_extracts = actions.append();
@@ -236,7 +216,7 @@ TEST(ascent_rover, test_xray_blueprint_braid)
           xray_query: 
             background_intensity: 0.0
             divide_emis_by_absorb: "false"
-            enable_imaging_planes: "false"
+            enable_rays_mesh: "false"
             height: 200
             precision: "double"
             width: 200
@@ -316,7 +296,6 @@ TEST(ascent_rover, test_xray_blueprint_braid_rotated)
     extracts["e1/params/rover/filename"] = query_path;
     extracts["e1/params/rover/output_type"] = "json";
     extracts["e1/params/rover/background_intensity"] = 100.0f;
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
     extracts["e1/params/camera/azimuth"] = 45.0;
     extracts["e1/params/camera/elevation"] = 45.0;
 
@@ -465,7 +444,6 @@ TEST(ascent_rover, test_xray_blueprint_curv3d)
     extracts["e1/params/rover/filename"] = query_path;
     extracts["e1/params/rover/output_type"] = "yaml";
     extracts["e1/params/rover/precision"] = "double";
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
 
     conduit::Node actions;
     conduit::Node &add_extracts = actions.append();
@@ -497,7 +475,7 @@ TEST(ascent_rover, test_xray_blueprint_curv3d)
         xray_query: 
           background_intensity: 0.0
           divide_emis_by_absorb: "false"
-          enable_imaging_planes: "false"
+          enable_rays_mesh: "false"
           height: 200
           precision: "double"
           width: 200
@@ -577,7 +555,6 @@ TEST(ascent_rover, test_xray_blueprint_curv3d_rotated)
     extracts["e1/params/rover/emission"] = "p";
     extracts["e1/params/rover/filename"] = query_path;
     extracts["e1/params/rover/output_type"] = "json";
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
     extracts["e1/params/camera/azimuth"] = 45.0;
     extracts["e1/params/camera/elevation"] = 45.0;
 
@@ -637,7 +614,6 @@ TEST(ascent_rover, test_xray_blueprint_curv3d_camera_params)
     extracts["e1/params/rover/emission"] = "p";
     extracts["e1/params/rover/filename"] = query_path;
     extracts["e1/params/rover/output_type"] = "hdf5";
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
 
     // These errors all originate from within rover
     // TODO: Setting anything for position (e.g. 0,0,0) throws a vector range error
@@ -676,7 +652,7 @@ TEST(ascent_rover, test_xray_blueprint_curv3d_camera_params)
     ASCENT_ACTIONS_DUMP(actions, query_path, msg);
 }
 
-// TODO: Add a test for imaging planes
+// TODO: Add a test for imaging planes and the rays mesh
 
 //-----------------------------------------------------------------------------
 TEST(ascent_rover, test_xray_blueprint_multi_curv3d)
@@ -718,7 +694,6 @@ TEST(ascent_rover, test_xray_blueprint_multi_curv3d)
     // dataset has an artifact in the intensity output
     // extracts["e1/params/rover/precision"] = "double";
     extracts["e1/params/rover/divide_emis_by_absorb"] = "true";
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
 
     conduit::Node actions;
     conduit::Node &add_extracts = actions.append();
@@ -750,7 +725,7 @@ TEST(ascent_rover, test_xray_blueprint_multi_curv3d)
         xray_query:
           background_intensity: 0.0
           divide_emis_by_absorb: "true"
-          enable_imaging_planes: "false"
+          enable_rays_mesh: "false"
           height: 200
           precision: "single"
           width: 200
@@ -830,7 +805,6 @@ TEST(ascent_rover, test_xray_blueprint_multi_curv3d_rotated)
     extracts["e1/params/rover/emission"] = "p";
     extracts["e1/params/rover/filename"] = query_path;
     extracts["e1/params/rover/output_type"] = "json";
-    extracts["e1/params/rover/enable_imaging_planes"] = "false"; // TODO: Remove this once issue #1559 is fixed
     extracts["e1/params/camera/azimuth"] = 45.0;
     extracts["e1/params/camera/elevation"] = 45.0;
 


### PR DESCRIPTION
Addresses bullets in #1513
- Removes the box clipping workaround for rover's tests now that #1559 is fixed.
- The "enable_imaging_planes" setting was no longer needed and has been reworked into "enable_rays_mesh".
- Updates Windows CI to upload test output as an artifact, since we don't have an easy way to re-run Windows CI locally.

Note: none of the baseline images needed to change, they are still 1-1 identical.