### PR TITLE
fix mismatched caliper annotation

### DIFF
--- a/src/libs/vtkh/rendering/Scene.cpp
+++ b/src/libs/vtkh/rendering/Scene.cpp
@@ -256,6 +256,7 @@ Scene::Render()
 
     batch_start = batch_end;
   } // while
+   ASCENT_ANNOTATE_MARK_END("scene render batches");
 }
 
 void Scene::SynchDepths(std::vector<vtkh::Render> &renders)


### PR DESCRIPTION
resolves #1597

lesson learned: the mismatched names shown aren't likely the directly the culprit, but help you know where to hunt