### PR TITLE
Pin GHA dependencies by hash

### DIFF
--- a/.github/workflows/build_ascent_cuda.yml
+++ b/.github/workflows/build_ascent_cuda.yml
@@ -13,7 +13,7 @@ jobs:
       CMAKE_VERSION: 3.24.4
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
     - name: Install CMake

--- a/.github/workflows/build_ascent_gcc.yml
+++ b/.github/workflows/build_ascent_gcc.yml
@@ -45,7 +45,7 @@ jobs:
                                 libopenmpi-dev \
                                 cmake
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
     - name: Env Info
@@ -127,7 +127,7 @@ jobs:
                                 libopenmpi-dev \
                                 cmake
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
     - name: Env Info

--- a/.github/workflows/build_ascent_hip.yml
+++ b/.github/workflows/build_ascent_hip.yml
@@ -13,7 +13,7 @@ jobs:
       CMAKE_VERSION: 3.24.4
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
     - name: Install CMake

--- a/.github/workflows/build_ascent_icc.yml
+++ b/.github/workflows/build_ascent_icc.yml
@@ -49,7 +49,7 @@ jobs:
         sudo apt install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.1.0 \
                        intel-oneapi-compiler-fortran-2023.1.0
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
     - name: Build TPLs

--- a/.github/workflows/build_ascent_macos.yml
+++ b/.github/workflows/build_ascent_macos.yml
@@ -13,7 +13,7 @@ jobs:
       CXX: clang++
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
     - name: Build TPLs

--- a/.github/workflows/build_ascent_win.yml
+++ b/.github/workflows/build_ascent_win.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: windows-2025
     steps:
     - name: Setup MPI
-      uses: mpi4py/setup-mpi@v1
+      uses: mpi4py/setup-mpi@d0a3bf17a182b37921ff27a6737f9009ec76d3b6 # v1
     - name: Setup Python Env
       run: python3 -m pip install --upgrade pip numpy mpi4py wheel
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with: 
         submodules: 'recursive'
     - name: Build TPLs
@@ -43,7 +43,7 @@ jobs:
         cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Release --target RUN_TESTS
     - name: Upload Ascent Unit Test Artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: test-results
         path: build/tests/_output/


### PR DESCRIPTION
Hash-pinned dependencies are an important requirement enforced by the OpenSSF scorecard tool: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

This commit pins all GitHub Actions workflows to a commit hash.