### PR TITLE
Configure Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This commit adds a basic Dependabot configuration for GitHub Actions workflow updates.  In addition to keeping dependencies fresh, adding a Dependabot configuration allows the project to receive Dependabot security alerts if configured in the project settings: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates