### PR TITLE
Restrict workflow permissions to minimum required

### DIFF
--- a/.github/workflows/build_ascent_cuda.yml
+++ b/.github/workflows/build_ascent_cuda.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_cuda:
     name: Build Ascent CUDA

--- a/.github/workflows/build_ascent_gcc.yml
+++ b/.github/workflows/build_ascent_gcc.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_basic:
     name: Ubuntu Build Ascent GCC

--- a/.github/workflows/build_ascent_hip.yml
+++ b/.github/workflows/build_ascent_hip.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_cuda:
     name: Build Ascent HIP

--- a/.github/workflows/build_ascent_icc.yml
+++ b/.github/workflows/build_ascent_icc.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_basic:
     name: Ubuntu Build Ascent OpenAPI

--- a/.github/workflows/build_ascent_macos.yml
+++ b/.github/workflows/build_ascent_macos.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_basic:
     name: macOS Build Ascent Clang

--- a/.github/workflows/build_ascent_win.yml
+++ b/.github/workflows/build_ascent_win.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_windows_msvc_base:
     name: MSVC Base Release


### PR DESCRIPTION
Limiting the scope of the GITHUB_TOKEN via the [permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) attribute is best practice to prevent a leaked GITHUB_TOKEN from allowing repository write access.