### PR TITLE
expressions: add mesh blueprint support for "points" implicit topology

### DIFF
--- a/src/cmake/thirdparty/SetupOcca.cmake
+++ b/src/cmake/thirdparty/SetupOcca.cmake
@@ -9,7 +9,6 @@ endif()
 MESSAGE(STATUS "Looking for OCCA using OCCA_DIR = ${OCCA_DIR}")
 
 set(occa_DIR ${OCCA_DIR}/lib)
-message(STATUS "Found OCCA include dirs: ${OCCA_INCLUDE_DIRS}")
 
 find_path(OCCA_INCLUDE_DIRS occa.hpp
           PATHS ${OCCA_DIR}/include
@@ -18,6 +17,7 @@ find_path(OCCA_INCLUDE_DIRS occa.hpp
           NO_CMAKE_PATH
           NO_SYSTEM_ENVIRONMENT_PATH
           NO_CMAKE_SYSTEM_PATH)
+message(STATUS "Found OCCA include dirs: ${OCCA_INCLUDE_DIRS}")
 
 #find libs
 find_library(OCCA_LIBRARIES LIBRARIES NAMES occa

--- a/src/cmake/thirdparty/SetupViskores.cmake
+++ b/src/cmake/thirdparty/SetupViskores.cmake
@@ -17,7 +17,7 @@ MESSAGE(STATUS "Looking for Viskores using VISKORES_DIR = ${VISKORES_DIR}")
 # use VISKORES_DIR to setup the options that cmake's find Viskores needs
 file(GLOB Viskores_DIR "${VISKORES_DIR}/lib/cmake/viskores-*")
 if(NOT Viskores_DIR)
-    MESSAGE(FATAL_ERROR "Failed to find Viskores at VISKORES_DIR=${VISKORES_DIR}/lib/cmake/vtk-*")
+    MESSAGE(FATAL_ERROR "Failed to find Viskores at VISKORES_DIR=${VISKORES_DIR}/lib/cmake/viskores-*")
 endif()
 
 find_package(Viskores REQUIRED QUIET)

--- a/src/libs/ascent/runtimes/expressions/ascent_blueprint_topologies.cpp
+++ b/src/libs/ascent/runtimes/expressions/ascent_blueprint_topologies.cpp
@@ -670,12 +670,44 @@ topologyFactory(const std::string &topo_name, const conduit::Node &domain)
   const std::string &topo_type = n_topo["type"].as_string();
   const size_t num_dims = topo_dim(topo_name, domain);
   const std::string type = detail::coord_dtype(topo_name, domain);
-  if(topo_type == "uniform")
+  if(topo_type == "points")
   {
     if(type == "double")
     {
       switch(num_dims)
       {
+      case 1:
+        return my_make_unique<PointTopology<conduit::float64, 1>>(topo_name,
+                                                                  domain);
+        break;
+      case 2:
+        return my_make_unique<PointTopology<conduit::float64, 2>>(topo_name,
+                                                                  domain);
+        break;
+      case 3:
+        return my_make_unique<PointTopology<conduit::float64, 3>>(topo_name,
+                                                                  domain);
+        break;
+      }
+    } else {
+      switch (num_dims) {
+      case 1:
+        return my_make_unique<PointTopology<conduit::float32, 1>>(topo_name,
+                                                                  domain);
+        break;
+      case 2:
+        return my_make_unique<PointTopology<conduit::float32, 2>>(topo_name,
+                                                                  domain);
+        break;
+      case 3:
+        return my_make_unique<PointTopology<conduit::float32, 3>>(topo_name,
+                                                                  domain);
+        break;
+      }
+    }
+  } else if (topo_type == "uniform") {
+    if (type == "double") {
+      switch (num_dims) {
       case 1:
         return my_make_unique<UniformTopology<conduit::float64, 1>>(topo_name,
                                                                     domain);

--- a/src/libs/ascent/runtimes/expressions/ascent_blueprint_topologies.cpp
+++ b/src/libs/ascent/runtimes/expressions/ascent_blueprint_topologies.cpp
@@ -153,7 +153,7 @@ PointTopology<T, N>::PointTopology(const std::string &topo_name,
                                    const conduit::Node &domain)
     : Topology(topo_name, domain, N)
 {
-  if(this->topo_type != "point")
+  if(this->topo_type != "points")
   {
     ASCENT_ERROR("Cannot initialize a PointTopology class from topology '"
                  << topo_name << "' in domain " << domain.name()


### PR DESCRIPTION
Fix #1476

Note: I'm sorry in advance if I'm taking this too naively, any suggestion/hint is appreciated.

The main target of this PR is adding support for the ["points" implicit topology](https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#implicit-topology) of the mesh blueprint in expressions.