### PR TITLE
unstructured topology with point shape: fix performance problem

### DIFF
--- a/src/libs/ascent/runtimes/expressions/ascent_blueprint_topologies.cpp
+++ b/src/libs/ascent/runtimes/expressions/ascent_blueprint_topologies.cpp
@@ -583,7 +583,7 @@ UnstructuredTopology<T, N>::get_num_points() const
   const conduit::int32 *conn_end =
       conn_begin + connectivity.dtype().number_of_elements();
   // points used in the topology
-  const size_t num_points = std::unordered_set<T>(conn_begin, conn_end).size();
+  const size_t num_points = std::unordered_set<conduit::int32>(conn_begin, conn_end).size();
   // points available in the coordset
   const size_t coords_size = domain["coordsets/" + coords_name + "/values"]
                                  .child(0)


### PR DESCRIPTION
This PR fixes a problem that shouldn't produce any functional error, but it made this naive check super expensive. Indeed, due to the wrong type used for the `unordered_set`, with this fix my use-case went from ~3m to 12s.