### PR TITLE
Fix: build errors with VTKH enable with Kokkos HIP backend and ROCm 7.2.1

### DIFF
--- a/src/libs/ascent/ascent.cpp
+++ b/src/libs/ascent/ascent.cpp
@@ -626,6 +626,10 @@ Ascent::open(const conduit::Node &options)
               {
                 vtkh::ForceCUDA();
               }
+              else if(backend == "kokkos")
+              {
+                vtkh::ForceKokkos();
+              }
               else
               {
                 ASCENT_ERROR("Ascent unrecognized backend "<<backend);

--- a/src/libs/rover/CMakeLists.txt
+++ b/src/libs/rover/CMakeLists.txt
@@ -76,19 +76,22 @@ set(rover_headers
       ${CMAKE_CURRENT_BINARY_DIR}/rover_config.h
      )
 
-set(rover_sources
-      domain.cpp
-      image.cpp
-      rover.cpp
-      typed_scheduler.cpp
-      engine.cpp
-      # ray generators
-      ray_generators/ray_generator.cpp
-      ray_generators/visit_ray_generator.cpp
-      # utils sources
-      utils/rover_logging.cpp
-      utils/vtk_dataset_reader.cpp
- )
+set(rover_device_sources
+    domain.cpp
+    image.cpp
+    engine.cpp
+    ray_generators/ray_generator.cpp
+    ray_generators/visit_ray_generator.cpp
+)
+
+set(rover_host_sources
+    rover.cpp
+    typed_scheduler.cpp
+    utils/rover_logging.cpp
+    utils/vtk_dataset_reader.cpp
+)
+
+set(rover_sources ${rover_device_sources} ${rover_host_sources})
 
 ###############################################################################
 if (ENABLE_SERIAL)
@@ -98,7 +101,7 @@ if (ENABLE_SERIAL)
                     DEPENDS_ON ${rover_thirdparty_deps}
                     )
 
-    viskores_add_target_information(rover DEVICE_SOURCES ${rover_sources})
+    viskores_add_target_information(rover DEVICE_SOURCES ${rover_device_sources})
 
     # build includes
     # this allows us to include as <header.hpp>
@@ -140,7 +143,7 @@ if(MPI_FOUND)
                   DEPENDS_ON ${rover_mpi_thirdparty_deps}
                   )
 
-  viskores_add_target_information(rover_mpi DEVICE_SOURCES ${rover_sources})
+  viskores_add_target_information(rover_mpi DEVICE_SOURCES ${rover_device_sources})
 
   # build includes
   # this allows us to include as <rover/header.hpp>

--- a/src/utilities/actions_conversions/CMakeLists.txt
+++ b/src/utilities/actions_conversions/CMakeLists.txt
@@ -13,7 +13,7 @@
 set(yaml2json_sources
     yaml2json.cpp)
 
-set(yaml2json_deps conduit)
+set(yaml2json_deps conduit::conduit)
 
 blt_add_executable(
     NAME        yaml2json
@@ -32,7 +32,7 @@ install(TARGETS yaml2json
 set(json2yaml_sources
     json2yaml.cpp)
 
-set(json2yaml_deps conduit)
+set(json2yaml_deps conduit::conduit)
 
 blt_add_executable(
     NAME        json2yaml


### PR DESCRIPTION
I'm currently working on in-situ GPU, and building ascent with vtkh enabled and the Kokkos HIP backend, I had to make some fixes. Details of each fix are available in each commit message.

My configuration: ROCm 7.2.1 with the hip gfx1201 architecture.